### PR TITLE
build: Split Makefile build system into multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 ## Ignore project-specific files
 *[Ss][Cc][Uu][Ss]*
 *971*98*
-build*/
-*build/
+#build*/
+#*build/
 ProDGPs2usrLocalSceFiles.zip
 usr/
 sce/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ SDIR = src/P2
 SRCS := $(wildcard $(SDIR)/*.cpp)
 
 # Custom compiler flags
-CCFLAGS = -Wall -Wno-unused $(BASEFLAGS) -fno-strict-aliasing -g -I$(SCE_COMMON)/include -I$(SCE_EE)/include -I$(SDIR)
-CXXFLAGS = $(CCFLAGS) -fno-exceptions
+CCFLAGS = -Wall -Wno-unused $(BASEFLAGS) -fno-strict-aliasing -I$(SCE_COMMON)/include -I$(SCE_EE)/include -I$(SDIR)
+CXXFLAGS = $(CCFLAGS)
 LDFLAGS = -nostartfiles -Wl,-Map,$(NAME).map -T$(SCE_EE)/lib/app.cmd -L$(SCE_EE)/lib -lsn -lc -lm -lkernl
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,21 @@
-# SCE paths
-SCE := C:/usr/local/sce
-EE := $(SCE)/ee
-GCC := $(EE)/gcc
-
-# There's probably a slightly better detection heuristic
-# but this one seems to work more than well enough
-ifneq ($(OS),Windows_NT)
-CC := wine $(EE)/gcc/bin/ee-gcc.exe
-# driver doesn't exist for some reason
-CXX := wine $(EE)/gcc/bin/ee-gcc.exe
-# Unfortunately winepath emits a name that make chokes on
-# with a very cryptic error, so it has to be done like this :(
-CRT0_S := $(HOME)/.wine/drive_c/usr/local/sce/ee/lib/crt0.s
-else
-CC = $(EE)/gcc/bin/ee-gcc.exe
-CXX = $(EE)/gcc/bin/ee-gcc.exe
-CRT0_S := $(EE)/lib/crt0.s
-endif
-
-TARGET = SCUS_971.98
-TFLAGS = -G0 -fno-common
-
-ASFLAGS = $(TFLAGS)
-CFLAGS = -Wall -Wno-unused $(TFLAGS) -fno-strict-aliasing -g -I$(EE)/include
-CXXFLAGS = $(CFLAGS) -fno-exceptions
-LDFLAGS = -nostartfiles -Wl,-Map,$(TARGET).map -T$(EE)/lib/app.cmd -L$(EE)/lib -lsn -lc -lm -lkernl
+NAME := SCUS_971.98
+TARGET := ee
+TARGETTYPE := bin
 
 SDIR = src/P2
+SRCS := $(wildcard $(SDIR)/*.cpp)
 
-CFLAGS += -I$(SDIR)
+# Custom compiler flags
+CCFLAGS = -Wall -Wno-unused $(BASEFLAGS) -fno-strict-aliasing -g -I$(SCE_COMMON)/include -I$(SCE_EE)/include -I$(SDIR)
+CXXFLAGS = $(CCFLAGS) -fno-exceptions
+LDFLAGS = -nostartfiles -Wl,-Map,$(NAME).map -T$(SCE_EE)/lib/app.cmd -L$(SCE_EE)/lib -lsn -lc -lm -lkernl
 
-SRCS = $(wildcard $(SDIR)/*.cpp)
-OBJS = crt0.o $(SRCS:.cpp=.o)
 
+include build/core.mk
 
-.PHONY: all clean
+.PHONY: all clean clean-products
 
-all: $(TARGET)
+all: $(NAME)
 
-$(TARGET): $(OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDSCRIPT) $(LDFLAGS)
-
-# :( have to duplicate the rule
-crt0.o: $(CRT0_S)
-	$(CC) -c -xassembler-with-cpp $(CCFLAGS) $< -o $@
-
-%.o: %.s
-	$(CC) -c -xassembler-with-cpp $(CCFLAGS) $< -o $@
-
-%.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $< -o $@
-
-clean:
-	$(RM) -f $(OBJS) $(TARGET) $(TARGET).map
+clean: clean-products
+	rm -f $(NAME).map

--- a/build/core.mk
+++ b/build/core.mk
@@ -1,0 +1,29 @@
+# Core make entrypoint, used to unify/clean up rules
+#
+# NAME=NAME
+# TARGET=ee|iop
+# TARGETTYPE=bin|lib|irx
+# SRCS = sources...
+
+# TODO: Other configurations if possible
+debug_Valid := y
+release_Valid := y
+
+# There's probably a slightly better detection heuristic
+# but this one seems to work more than well enough
+ifneq ($(OS),Windows_NT)
+WINE := y
+else
+WINE := n
+endif
+
+ifeq ($(CONFIG),)
+CONFIG := debug
+endif
+
+ifneq ($($(CONFIG)_Valid),y)
+$(error Invalid configuration)
+endif
+
+include build/$(TARGET)-$(TARGETTYPE).mk
+

--- a/build/ee-bin.mk
+++ b/build/ee-bin.mk
@@ -1,7 +1,7 @@
 OBJS = crt0.o $(SRCS:.cpp=.o)
 
 $(NAME): $(OBJS)
-	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDSCRIPT) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean-products:
 	$(RM) -f $(OBJS) $(NAME)

--- a/build/ee-bin.mk
+++ b/build/ee-bin.mk
@@ -1,0 +1,9 @@
+OBJS = crt0.o $(SRCS:.cpp=.o)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDSCRIPT) $(LDFLAGS)
+
+clean-products:
+	$(RM) -f $(OBJS) $(NAME)
+
+include build/ee-common.mk

--- a/build/ee-common.mk
+++ b/build/ee-common.mk
@@ -1,0 +1,36 @@
+include build/sce-common.mk
+
+ifeq ($(WINE),y)
+CC := wine $(SCE_EE)/gcc/bin/ee-gcc.exe
+CXX := wine $(SCE_EE)/gcc/bin/ee-gcc.exe
+CRT0_S := $(SCE_WINE)/ee/lib/crt0.s
+else
+CC = $(SCE_EE_GCC)/bin/ee-gcc.exe
+CXX = $(SCE_EE_GCC)/bin/ee-gcc.exe
+CRT0_S := $(SCE_EE)/lib/crt0.s
+endif
+
+# shared for both c/c++ compilation
+BASEFLAGS = -G0 -fno-common
+
+ifeq ($(CONFIG),debug)
+	BASEFLAGS += -O0 -g
+endif
+
+ifeq ($(CONFIG),release)
+	BASEFLAGS += -O2
+endif
+
+# :( have to duplicate the rule
+crt0.o: $(CRT0_S)
+	$(CC) -c -xassembler-with-cpp $(CCFLAGS) $< -o $@
+
+%.o: %.s
+	$(CC) -c -xassembler-with-cpp $(CCFLAGS) $< -o $@
+
+
+%.o: %.c
+	$(CC) -c $(CXXFLAGS) $< -o $@
+
+%.o: %.cpp
+	$(CXX) -c $(CXXFLAGS) $< -o $@

--- a/build/sce-common.mk
+++ b/build/sce-common.mk
@@ -1,0 +1,15 @@
+# SCE common paths
+
+SCE = C:/usr/local/sce
+
+# Unfortunately winepath emits a name that make chokes on
+# with a very cryptic error, so we have to hardcode wine's
+# drive_c here.
+SCE_WINE = $(HOME)/.wine/drive_c/usr/local/sce
+
+SCE_COMMON = $(SCE)/common
+SCE_EE = $(SCE)/ee
+SCE_IOP = $(SCE)/iop
+
+SCE_EE_GCC = $(SCE_EE)/gcc
+SCE_IOP_GCC = $(SCE_IOP)/gcc


### PR DESCRIPTION
This PR makes a new build/ folder which contains auxiliary Makefiles that are used to assist/clean up the build a bit.

In theory, later on, (hinted by the documentation of build/core.mk), it may be possible to even add IOP target support, but for now, I have not yet added this to the buildsystem. It should be relatively easy, however.

Building should be exactly the same, except now there is a CONFIG= make variable which can be set (e.g: `make CONFIG=release`), which allows building different configurations (`debug`, which is the default, disables optimizations and generates debug information just like before, while `release` enables optimizations and does not generate debug info)