### PR TITLE
build: Add `objonly`/`objflush` targets

### DIFF
--- a/build/core.mk
+++ b/build/core.mk
@@ -7,6 +7,7 @@
 
 # TODO: Other configurations if possible
 debug_Valid := y
+#debugopt_Valid := y
 release_Valid := y
 
 # There's probably a slightly better detection heuristic
@@ -25,5 +26,24 @@ ifneq ($($(CONFIG)_Valid),y)
 $(error Invalid configuration)
 endif
 
+# Moved here since it doesn't really have to be specified in the target common file.
+OBJDIR := obj/$(CONFIG)
+
 include build/$(TARGET)-$(TARGETTYPE).mk
 
+# Make targets for allowing "only compile/only remove this object file" workflows
+# Useful for decompilation tooling that wants to use this.
+.PHONY: objonly objflush
+
+ifeq ($(COMPILEME),)
+# Running these targets without a object file to compile is a logic error.
+objonly:
+	$(error No object file provided, please set the COMPILEME variable to the object file you want to compile.)
+objflush:
+	$(error No object file provided)
+else
+objonly: $(OBJDIR)/ $(OBJDIR)/$(COMPILEME)
+	$(info $(OBJDIR)/$(COMPILEME))
+objflush:
+	$(RM) $(OBJDIR)/$(COMPILEME)
+endif

--- a/build/ee-common.mk
+++ b/build/ee-common.mk
@@ -10,7 +10,6 @@ CXX := $(SCE_EE_GCC)/bin/ee-gcc.exe
 CRT0_S := $(SCE_EE)/lib/crt0.s
 endif
 
-OBJDIR := obj/$(CONFIG)
 
 # Scary Make Incantations: Volume 1
 OBJS := $(patsubst %.cpp,$(OBJDIR)/%.o,$(filter %.cpp,$(notdir $(SRCS))))
@@ -21,11 +20,11 @@ OBJS += $(patsubst %.s,$(OBJDIR)/%.o,$(filter %.s,$(notdir $(SRCS))))
 BASEFLAGS := -G0 -fno-common
 
 ifeq ($(CONFIG),debug)
-	BASEFLAGS += -O2 -g
+BASEFLAGS += -O2 -g
 endif
 
 ifeq ($(CONFIG),release)
-	BASEFLAGS += -O2
+BASEFLAGS += -O2
 endif
 
 $(OBJDIR)/%.o: %.s
@@ -36,4 +35,3 @@ $(OBJDIR)/%.o: %.c
 
 $(OBJDIR)/%.o: %.cpp
 	$(CXX) -c $(CXXFLAGS) $< -o $@
-


### PR DESCRIPTION
This allows tooling (or developers) to build a single object file simply by specifying the object to compile and running the "objonly" target.

For example: `make COMPILEME=bis.o objonly` will compile only bis.o and also output the path to the final/resulting object file, useful for tools which want to then open said object file.

The "objflush" target also exists for if a clean build of the object file is required, and acts like "clean" but with only the single object file.