### PR TITLE
Update scripts and Windows build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,61 +55,68 @@ pip install -U -r requirements.txt
 
 ### Setup build environment
 
-The `scripts` directory contains scripts for setting up the build environment on Windows and Linux, which automatically download and install the required runtime libraries. Follow the instruction for your platform below.
+The project can be built on Windows (using WSL) or Linux. Follow the instructions below to set up the build environment.
 
-#### Linux/WSL
+<!--#### Linux/WSL-->
 
-Setup wine:
+1. Setup wine:
 ```bash
 sudo dpkg --add-architecture i386
 sudo apt-get update
 sudo apt-get install wine32
 ```
 
-Install binutils:
+2. Install MIPS assembler:
 ```bash
-suto apt-get install binutils-mips-linux-gnu
+sudo apt-get install binutils-mips-linux-gnu
 ```
 
-Setup build environment:
+3. Setup build environment:
 ```bash
 cd scripts
 ./setup-progd-linux.sh
 ```
 
-#### Windows
+<!--#### Windows
 
-*Note: Building on Windows is untested with the new build system, and may not work as expected. If you encounter issues, you can still build on Windows using WSL.*
+*Prerequisites: [Chocolatey](https://chocolatey.org/install)*
 
-Install 7zip:
+1. Install 7zip:
 ```powershell
-winget install 7zip
+choco install 7zip
 ```
 
-Setup build environment:
+2. Setup build environment:
 ```powershell
 .\scripts\setup-progd-windows.bat
-```
+```-->
 
 ### Setup binary splitting
 
-To build the ELF , you will need to extract the original ELF file from your own legally obtained copy of the game. Mount the disk on your PC and copy the file `SCUS_971.98` from the root directory of the disc to the `disc` directory of this project.
+To build the ELF, you will need to extract the original ELF file from your own legally obtained copy of the game. Mount the disk on your PC and copy the file `SCUS_971.98` from the root directory of the disc to the `disc` directory of this project.
 
 
 ## Building
 
-The project can be compiled on Windows (using WSL) or Linux. It builds the executable `SCUS_971.98`.
+The project can be built on Windows (using WSL) or Linux. It builds the executable `SCUS_971.98`.
 
-First configure the project:
+The configure.py script will automatically split the binary and generate the build files. Then you can build the project with Ninja.
 
 ```bash
 python configure.py
+ninja
 ```
 
-Then build with Ninja:
+If you update the config files, you will need to clean and reconfigure:
 
 ```bash
-ninja
+python configure.py --clean
+```
+
+To only clean and not reconfigure, run:
+
+```bash
+python configure.py --only-clean
 ```
 
 

--- a/configure.py
+++ b/configure.py
@@ -231,7 +231,10 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.clean or args.only_clean:
+    do_clean = (args.clean or args.only_clean) or False
+    do_skip_checksum = args.skip_checksum or False
+
+    if do_clean:
         clean()
         if args.only_clean:
             return
@@ -240,10 +243,7 @@ def main():
 
     linker_entries = split.linker_writer.entries
 
-    if args.skip_checksum:
-        build_stuff(linker_entries, skip_checksum=True)
-    else:
-        build_stuff(linker_entries)
+    build_stuff(linker_entries, do_skip_checksum)
 
     write_permuter_settings()
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,9 +2,11 @@
 
 # ##############################################################################
 # Set these paths to point to your PCSX2 1.7 executable and your copy of the game
-PCSX2_PATH="/opt/pcsx2-1.7.AppImage"
+PCSX2_PATH=""
 ISO_PATH=""
 # ##############################################################################
+ELF_PATH="out/SCUS_971.98"
+OPTONS="-fastboot -nogui"
 
 # Expand aliases
 shopt -s expand_aliases
@@ -32,34 +34,34 @@ fi
 if [ -z "$ISO_PATH" ]; then
     echo "Warning: ISO path is empty, please edit the paths in 'scripts/run.sh'"
 # Error if ISO path is not valid
-elif [ ! -f "$ISO_PATH" ]; then
-    die Game ISO not found at '$ISO_PATH'
+elif [ -f "$ISO_PATH" ]; then
+    die Game ISO not found at $ISO_PATH
     exit 1
 fi
 
 # Error if PCSX2 is not valid
-if [ ! -f "$PCSX2_PATH" ]; then
-    die PCSX2 executable not found at '$PCSX2_PATH'
-    exit 1
-fi
+#if [ -f "$PCSX2_PATH" ]; then
+#    die PCSX2 executable not found at $PCSX2_PATH
+#    exit 1
+#fi
 
 # Show error message if PCSX2 is not executable
-if [ ! -x "$PCSX2_PATH" ]; then
-    die PCSX2 executable is not executable
-    exit 1
-fi
+#if [ -x "$PCSX2_PATH" ]; then
+#    die PCSX2 executable is not executable
+#    exit 1
+#fi
 
 # Switch to the project root directory
 pushd "$(dirname "$0")/.." > /dev/null
 
 # Build the game
 echo Compiling ELF...
-#make clean > /dev/null
-make > /dev/null
+#python3 configure.py --clean
+ninja
 
 # Run the game
 echo Booting ELF in PCSX2...
-"$PCSX2_PATH" -elf bin/debug/SCUS_971.98 $ISO_PATH
+"$PCSX2_PATH" -elf $ELF_PATH $OPTIONS -- $ISO_PATH
 
 # Switch back to the original directory
 popd > /dev/null

--- a/scripts/setup_prodg_windows.bat
+++ b/scripts/setup_prodg_windows.bat
@@ -19,7 +19,13 @@ REM download_file: URL
 REM downloads file using curl
 :download_file
 echo Downloading %~1...
-curl -sS %~1 -o %TEMP%\%~nx1
+set output_file=%TEMP%\progd.zip
+curl -L %~1 -o %output_file%
+if exist "%output_file%" (
+    echo File downloaded to %output_file%
+) else (
+    call :die Failed to download file
+)
 goto :eof
 
 
@@ -33,17 +39,17 @@ echo
 REM download required files (registry + SDK package)
 call :download_file "https://github.com/TheOnlyZac/compilers/releases/download/ee-gcc2.95.2-SN-v2.73a/ee-gcc2.95.2-SN-v2.73a.zip"
 
-REM apply environment variables from the registry file
-echo Applying environment variables, please accept the UAC prompt
-regedit %TEMP%\prodg_env.reg
+::REM apply environment variables from the registry file
+::echo Applying environment variables, please accept the UAC prompt
+::regedit %TEMP%\prodg_env.reg
 
 REM Extract the compiler to the project/tools directory
 echo Extracting compiler to tools directory...
-7z x -y %TEMP%\ee-gcc2.95.2-SN-v2.73a.zip -otools
+7z x -y %TEMP%\progd.zip -otools
 
 ::echo Removing temporary files
 echo Removing temporary files...
-del %TEMP%\ee-gcc2.95.2-SN-v2.73a.zip
+::del %TEMP%\ee-gcc2.95.2-SN-v2.73a.zip
 
 echo Setup complete!
 endlocal


### PR DESCRIPTION
Updated the readme to reflect that building on Windows is only possible with WSL. Also tweaked the `configure.py`, `run.sh`, and `setup_progd_windows.bat` scripts.