### PR TITLE
Some matching for dl.c

### DIFF
--- a/config/sly1.yaml
+++ b/config/sly1.yaml
@@ -128,7 +128,7 @@ segments:
     #- [0x, asm, P2/dialog]
 
     - [0x529e0, c, P2/difficulty]
-    - [0x53438, asm, P2/dl]
+    - [0x53438, c, P2/dl]
 
     - [0x53810, asm, P2/dmas]
     #- [0x, asm, P2/dsp]

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -654,7 +654,18 @@ g_difficulty = 0x261ef0; // size:0x20
 ////////////////////////////////////////////////////////////////
 // P2/dl.c
 ////////////////////////////////////////////////////////////////
+InitDl__FP2DLi = 0x152438; // type:func
+ClearDl__FP2DL = 0x152440; // type:func
+ClearDle__FP3DLE = 0x152450; // type:func
+PdleFromDlEntry__FP2DLPv = 0x152460; // type:func
 AppendDlEntry__FP2DLPv = 0x152470; // type:func
+PrependDlEntry__FP2DLPv = 0x1524D8; // type:func
+InsertDlEntryBefore__FP2DLPvT1 = 0x152540; // type:func
+RemoveDlEntry__FP2DLPv = 0x152600; // type:func
+FFindDlEntry__FP2DLPv = 0x1526D0; // type:func
+FIsDlEmpty__FP2DL = 0x152720; // type:func
+MergeDl__FP2DLT0 = 0x152730; // type:func
+CPvDl__FP2DL = 0x1527D8; // type:func
 
 ////////////////////////////////////////////////////////////////
 // P2/find.c

--- a/include/dl.h
+++ b/include/dl.h
@@ -8,22 +8,22 @@
 #include <oid.h>
 
 /**
- * @brief Unknown.
+ * @brief Doubly Linked list
  */
 struct DL
 {
-    undefined4 unk_1;
-    undefined4 unk_2;
+    void* head;
+    void* tail;
     int ibDle;
 };
 
 /**
- * Unknown.
+ * Doubly Linked list Element
  */
 struct DLE
 {
-    undefined4 unk_1;
-    undefined4 unk_2;
+    void* next;
+    void* prev;
 };
 
 /**
@@ -54,7 +54,102 @@ struct DLR
     DLR *pdlrNext;
 };
 
+/**
+ * @brief Initialize a doubly linked list.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @param ibDle Offset to the DLE structure within the list element.
+ */
 void InitDl(DL *pdl,int ibDle);
+
+/**
+ * @brief Clear a doubly linked list.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ */
+void ClearDl(DL *pdl);
+
+/**
+ * @brief Clear a doubly linked list element.
+ * 
+ * @param pdle Pointer to the doubly linked list element.
+ */
+void ClearDle(DLE *pdle);
+
+/**
+ * @brief Get the DLE structure from a list element.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @param pv Pointer to the list element.
+ * @return Pointer to the DLE structure.
+ */
+DLE *PdleFromDlEntry(DL *pdl, void *pv);
+
+/**
+ * @brief Append an element to the end of the doubly linked list.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @param pv Pointer to the list element.
+ */
 void AppendDlEntry(DL *pdl,void *pv);
+
+/**
+ * @brief Prepend an element to the beginning of the doubly linked list.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @param pv Pointer to the list element.
+ */
+void PrependDlEntry(DL *pdl, void *pv);
+
+/**
+ * @brief Insert an element before a specified element in the doubly linked list.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @param pvNext Pointer to the element before which the new element will be inserted.
+ * @param pv Pointer to the new list element.
+ */
+void InsertDlEntryBefore(DL *pdl, void *pvNext, void *pv);
+
+/**
+ * @brief Remove an element from the doubly linked list.
+ * 
+ * @param pdl Doubly linked list to remove the element from.
+ * @param pv Element to remove.
+ */
+void RemoveDlEntry(DL *pdl, void *pv);
+
+/**
+ * @brief Determine if a list element is in the doubly linked list.
+ * 
+ * @param pdl Doubly linked list to search.
+ * @param pv List element to search for.
+ * @return true if the element is in the list, false otherwise.
+ */
+bool FFindDlEntry(DL *pdl, void *pv);
+
+/**
+ * @brief Check if the doubly linked list is empty.
+ * 
+ * @param pdl Pointer to the doubly linked list.
+ * @return true if the list is empty, false otherwise.
+ */
+bool FIsDlEmpty(DL *pdl);
+
+/**
+ * @brief Merge two doubly linked lists. 
+ * 
+ * @param pdlDst Destination doubly linked list.
+ * @param pdlSrc Source doubly linked list.
+ */
+void MergeDl(DL *pdlDst, DL *pdlSrc);
+
+/**
+ * @brief Traverse a doubly linked list starting from the head and count the number of elements.
+ *
+ * @param pdl Pointer to the doubly linked list.
+ * @return The number of elements in the doubly linked list.
+ */
+int CPvDl(DL *pdl);
+
 
 #endif // DL_H

--- a/src/P2/dl.c
+++ b/src/P2/dl.c
@@ -1,0 +1,95 @@
+#include "common.h"
+#include <dl.h>
+
+void InitDl(DL *pdl, int ibDle)
+{
+    pdl->ibDle = ibDle;
+}
+
+void ClearDl(DL *pdl)
+{
+    pdl->tail = nullptr;
+    pdl->head = nullptr;
+}
+
+void ClearDle(DLE *pdle)
+{
+    pdle->prev = nullptr;
+    pdle->next = nullptr;
+}
+
+DLE *PdleFromDlEntry(DL *pdl, void *pv)
+{
+    return (DLE *)((u8 *)pv + pdl->ibDle);
+}
+
+void AppendDlEntry(DL *pdl, void *pv)
+{
+    DLE *newEntry = PdleFromDlEntry(pdl, pv);
+    if (pdl->tail == nullptr)
+    {
+        pdl->head = pv;
+    }
+    else
+    {
+        DLE *currentTail = PdleFromDlEntry(pdl, pdl->tail);
+        newEntry->prev = pdl->tail;
+        currentTail->next = pv;
+    }
+    pdl->tail = pv;
+}
+
+void PrependDlEntry(DL *pdl, void *pv)
+{
+    DLE *newEntry = PdleFromDlEntry(pdl, pv);
+    if (pdl->head == nullptr)
+    {
+        pdl->tail = pv;
+        pdl->head = pv;
+    }
+    else
+    {
+        DLE *currentHead = PdleFromDlEntry(pdl, pdl->head);
+        newEntry->next = pdl->head;
+        currentHead->prev = pv;
+        pdl->head = pv;
+    }
+}
+
+void InsertDlEntryBefore(DL *pdl, void *pvNext, void *pv)
+{
+    if (pvNext == nullptr)
+    {
+        AppendDlEntry(pdl, pv);
+    }
+    else if (pvNext == pdl->head)
+    {
+        PrependDlEntry(pdl, pv);
+    }
+    else
+    {
+        DLE *newEntry = PdleFromDlEntry(pdl, pv);
+        DLE *nextEntry = PdleFromDlEntry(pdl, pvNext);
+        void* prevEntryPointer = nextEntry->prev;
+        DLE *prevEntry = PdleFromDlEntry(pdl, prevEntryPointer);
+        newEntry->next = pvNext;
+        newEntry->prev = prevEntryPointer;
+        nextEntry->prev = pv;
+        prevEntry->next = pv;
+    }
+}
+
+INCLUDE_ASM(const s32, "P2/dl", func_001525F8);
+
+INCLUDE_ASM(const s32, "P2/dl", RemoveDlEntry__FP2DLPv);
+
+INCLUDE_ASM(const s32, "P2/dl", FFindDlEntry__FP2DLPv);
+
+bool FIsDlEmpty(DL *pdl)
+{
+    return pdl->head == nullptr;
+}
+
+INCLUDE_ASM(const s32, "P2/dl", MergeDl__FP2DLT0);
+
+INCLUDE_ASM(const s32, "P2/dl", CPvDl__FP2DL);


### PR DESCRIPTION
Took some liberties on a couple names that didn't have anything present in the prototype. There's some odd logic occurring in the unmatched functions, its totally possible that void* isn't a sufficient type for some member variables that could cause the confusions but it provides a good base point for now