### PR TITLE
chore(build): Tell driver where compiler executables are explicitly

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -29,7 +29,7 @@ PRE_ELF_PATH = f"{OUTDIR}/{BASENAME}.elf"
 COMMON_INCLUDES = "-Iinclude -isystem include/sdk/ee -isystem include/gcc"
 
 CC_DIR = f"{TOOLS_DIR}/cc/bin"
-COMMON_COMPILE_FLAGS = "-x c++ -V 2.95.2 -O2 -G0 -ffast-math"
+COMMON_COMPILE_FLAGS = f"-x c++ -B{TOOLS_DIR}/cc/lib/gcc-lib/ee/2.95.2/ -O2 -G0 -ffast-math"
 
 WINE = "wine"
 


### PR DESCRIPTION
The -V option is "used to control which version of gcc to run" (according to GCC2 documentation; this parameter doesn't exist in later GCC driver versions), but it adds the selected version to the usual /usr/local/sce/ee/gcc/lib... path, which doesn't really exist. Thus warnings are emitted from the driver on every ee-gcc invocation that that path was never used (because a fallback `../lib/gcc-lib` one *was*).

Instead, the -B option directly overrides the path the driver uses for compiler executables, avoiding these warnings entirely.