### PR TITLE
Match basic.c

### DIFF
--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -406,6 +406,7 @@ GGetActsegPoseGoal__FP6ACTSEGi = 0x123358; // type:func
 ////////////////////////////////////////////////////////////////
 FIsBasicDerivedFrom__FP5BASIC3CID = 0x1300e8; // type:func
 EnsureBasicSidebag__FP5BASIC = 0x130110; // type:func
+GetBasicCid__FP5BASICP3CID = 0x130158; // type:func
 
 
 ////////////////////////////////////////////////////////////////

--- a/include/basic.h
+++ b/include/basic.h
@@ -8,7 +8,7 @@
 
 #include "common.h"
 #include <splice/sidebag.h>
-#include <cid.h>
+#include <vtables.h>
 
 /**
  * @brief Basic object.
@@ -19,7 +19,7 @@
  */
 struct BASIC
 {
-    int field_0x0; // placeholder for vtable
+    VTBASIC *pvtbasic;
     CSidebag *psidebag;
 };
 

--- a/include/splice/sidebag.h
+++ b/include/splice/sidebag.h
@@ -28,4 +28,6 @@ private:
     SBB m_asbb[16];
 };
 
+CSidebag* PsidebagNew();
+
 #endif // SPLICE_SIDEBAG_H

--- a/include/vtables.h
+++ b/include/vtables.h
@@ -6,7 +6,20 @@
 #ifndef VTABLES_H
 #define VTABLES_H
 
+#include <cid.h>
+
 struct BLOT;
+
+/**
+ * @brief VT for basic objects.
+ * 
+ * @todo pvtSuper should be VT* according to prototype.
+ */
+struct VTBASIC
+{
+    VTBASIC *pvtSuper;
+    CID cid;
+};
 
 /**
  * @brief VT for generic blots.

--- a/src/P2/basic.c
+++ b/src/P2/basic.c
@@ -6,7 +6,7 @@ extern CGc g_gc;
 
 int FIsBasicDerivedFrom(BASIC *pbasic, CID cid) {
     VTBASIC *vt = pbasic->pvtbasic;
-    while (vt != 0) {
+    while (vt != nullptr) {
         if (vt->cid == cid) return 1;
         vt = vt->pvtSuper;
     }
@@ -15,7 +15,7 @@ int FIsBasicDerivedFrom(BASIC *pbasic, CID cid) {
 }
 
 void EnsureBasicSidebag(BASIC *pbasic) {
-    if (pbasic->psidebag == 0) {
+    if (pbasic->psidebag == nullptr) {
         CSidebag *psidebag = PsidebagNew();
         pbasic->psidebag = psidebag;
         g_gc.AddRootSidebag(psidebag);
@@ -23,4 +23,6 @@ void EnsureBasicSidebag(BASIC *pbasic) {
     return;
 }
 
-INCLUDE_ASM(const s32, "P2/basic", func_00130158);
+void GetBasicCid(BASIC *pbasic, CID* pcid) {
+    *pcid = pbasic->pvtbasic->cid;
+}

--- a/src/P2/basic.c
+++ b/src/P2/basic.c
@@ -1,6 +1,14 @@
 #include <basic.h>
 
-INCLUDE_ASM(const s32, "P2/basic", FIsBasicDerivedFrom__FP5BASIC3CID);
+int FIsBasicDerivedFrom(BASIC *pbasic, CID cid) {
+    VTBASIC *vt = pbasic->pvtbasic;
+    while (vt != 0) {
+        if (vt->cid == cid) return 1;
+        vt = vt->pvtSuper;
+    }
+
+    return 0;
+}
 
 INCLUDE_ASM(const s32, "P2/basic", EnsureBasicSidebag__FP5BASIC);
 

--- a/src/P2/basic.c
+++ b/src/P2/basic.c
@@ -1,4 +1,8 @@
 #include <basic.h>
+#include <splice/gc.h>
+#include <splice/sidebag.h>
+
+extern CGc g_gc;
 
 int FIsBasicDerivedFrom(BASIC *pbasic, CID cid) {
     VTBASIC *vt = pbasic->pvtbasic;
@@ -10,6 +14,13 @@ int FIsBasicDerivedFrom(BASIC *pbasic, CID cid) {
     return 0;
 }
 
-INCLUDE_ASM(const s32, "P2/basic", EnsureBasicSidebag__FP5BASIC);
+void EnsureBasicSidebag(BASIC *pbasic) {
+    if (pbasic->psidebag == 0) {
+        CSidebag *psidebag = PsidebagNew();
+        pbasic->psidebag = psidebag;
+        g_gc.AddRootSidebag(psidebag);
+    }
+    return;
+}
 
 INCLUDE_ASM(const s32, "P2/basic", func_00130158);


### PR DESCRIPTION
Probably need to revisit this when I get a better understanding of the whole vtable setup in the prototype, but this is enough to match these functions.

FIsBasicDerivedFrom__FP5BASIC3CID https://decomp.me/scratch/2wbMY
EnsureBasicSidebag__FP5BASIC https://decomp.me/scratch/02Z6P
GetBasicCid__FP5BASICP3CID https://decomp.me/scratch/HPC2v