### PR TITLE
Integrate objdiff reports and CI with decomp.dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Check build status
+name: Build and validate checksum
 
 on:
   push:

--- a/.github/workflows/frogress.yml
+++ b/.github/workflows/frogress.yml
@@ -1,22 +1,22 @@
-name: Frogress
+name: Post progress to Frogress
 
 on:
   push:
     branches:
       - main
-      - frogress
+      - progress
 
 jobs:
-  update-progress:
+  frogress-upload:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.x"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -1,22 +1,23 @@
-name: Check build status
+name: Upload progress report
 
 on:
   push:
     branches:
-      - "*"
+      - main
+      - progress
 
 jobs:
-  build:
-    if: github.repository_owner == 'theonlyzac'
+  report-upload:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.9.x"
 
       - name: Install dependencies
         run: |
@@ -35,7 +36,14 @@ jobs:
           scripts/setup_progd_linux.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
-      - name: Run build script
+      - name: Configure and generate report
         run: |
-          python configure.py
+          python configure.py --objects
           ninja
+          ./tools/objdiff/objdiff-cli report generate > report.json
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SCUS_971.98_report
+          path: ./report.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,17 @@ SCUS_*.*
 *.elf
 disc/*
 reference/*
-objdiff.json
 
+# Objdiff files
+objdiff.json
+report.json
+
+# Compiler
 prodg*
 tools/cc/
 usr/
 
+# Documentation
 html/
 
 # Splat files

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The default behavior is to split the binary using Splat, build the object files 
 You can alter the behavior by passing any of the following arguments to  `configure.py`:
 
 * `--clean` - Delete any existing build files and configure the project.
-* `--only-clean` - Delete any existing build files **without** configuring the project.
+* `--clean-only` - Delete any existing build files **without** configuring the project.
 * `--skip-checksum` - Skip the checksum verification step. This is necessary if you are intentionally changing the code, but note that the elf may not boot.
 * `--objects` - Builds the object files for matching with objdiff and generates an objdiff config file. Outputs two sets of object files: `obj/target` and `obj/matching` (the latter of which will be updated automatically by objdiff as you edit the source code).
 

--- a/src/P2/util.c
+++ b/src/P2/util.c
@@ -109,31 +109,33 @@ int FFloatsNear(float g1, float g2, float gEpsilon)
  * @todo 94.29% matched
  */
 INCLUDE_ASM(const s32, "P2/util", CSolveQuadratic__FfffPf);
-// int CSolveQuadratic(float a, float b, float c, float *ax)
-// {
-//     float alpha;
-//     float beta;
+#ifdef SKIP_ASM
+int CSolveQuadratic(float a, float b, float c, float *ax)
+{
+    float alpha;
+    float beta;
 
-//     alpha = b * b - 4.f * a * c;
-//     a = a * 2;
+    alpha = b * b - 4.f * a * c;
+    a = a * 2;
 
-//     if (alpha < 0.0f)
-//     {
-//         return 0;
-//     }
+    if (alpha < 0.0f)
+    {
+        return 0;
+    }
 
-//     beta = b / a;
-//     alpha = sqrtf(alpha) / a;
-//     if (fabsf(alpha) < 0.0001f)
-//     {
-//         *ax = -beta;
-//         return 1;
-//     }
+    beta = b / a;
+    alpha = sqrtf(alpha) / a;
+    if (fabsf(alpha) < 0.0001f)
+    {
+        *ax = -beta;
+        return 1;
+    }
 
-//     *ax = -beta + alpha;
-//     ax[1] = -beta - alpha;
-//     return 2;
-// }
+    *ax = -beta + alpha;
+    ax[1] = -beta - alpha;
+    return 2;
+}
+#endif
 
 void PrescaleClq(CLQ *pclqSrc, float ru, float du, CLQ *pclqDst)
 {


### PR DESCRIPTION
I added a CI workflow to generate a report with objdiff and upload it as an artifact to the repo, for integration with [decomp.dev](https://decomp.dev).