### PR TITLE
Match NLog2, some bis and text functions

### DIFF
--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -1226,6 +1226,7 @@ g_apchzArgs = 0x264838; // size:0x4
 // P2/memory.c
 ////////////////////////////////////////////////////////////////
 PvAllocGlobalImpl__Fi = 0x18D4B0; // type:func
+PvAllocSwImpl__Fl = 0x18d500; // type:func
 CopyAb__FPvT0Ui = 0x18d800; // type:func
 
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -15,4 +15,11 @@
  */
 void CopyAb(void *pvDst, void *pvSrc, uint cb);
 
+/**
+ * @brief Allocate a block of memory.
+ *
+ * @param size Size of the block in bytes.
+ */
+void *PvAllocSwImpl(long size);
+
 #endif // MEMORY_H

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -61,50 +61,43 @@ int CBinaryInputStream::FOpenFile(CFileLocation *pfl)
     return FOpenSector(pfl->m_fcl.isector, pfl->m_fcl.cb);
 }
 
-INCLUDE_ASM(const s32, "P2/bis", Close__18CBinaryInputStream);
-#ifdef SKIP_ASM
-/**
- * @todo 81.16% matched
- */
 void CBinaryInputStream::Close()
 {
-    if (m_bisk == BISK_Host) {
-        if (-1 < m_fd) {
-            sceClose(m_fd);
+    switch(m_bisk)
+    {
+        case BISK_Host:
+        {
+            // NOTE: This is m_fd if m_tickWait is removed.
+            if(*(int *)((uint8_t *)&m_tickWait - 0x4) >= 0)
+                sceClose(*(int *)((uint8_t *)&m_tickWait - 0x4));
+            break;
         }
-    }
-    else {
-        if (m_bisk != BISK_Cd) {
-            m_cbSpillOver = 0;
-            m_bisk = BISK_Nil;
-            m_pbRaw = 0x0;
-            m_pb = 0x0;
-            m_cbRaw = 0;
-            m_cb = 0;
-            m_grfDecomp = 0;
-            return;
-        }
-        if (m_cbAsyncRequest != 0) {
-            if ((m_grfbis & 2U) == 0) {
-                sceCdBreak();
+        case BISK_Cd:
+        {
+            // NOTE: This is m_cbAsyncComplete if m_tickWait is removed.
+            if(*(int *)((uint8_t *)this + 0x3c))
+            {
+                if(m_grfbis & 0x2)
+    			{
+                    sceCdBreak();
+                }
+    			else
+    			{
+                    snd_StreamSafeCdBreak();
+                }
             }
-            else {
-                snd_StreamSafeCdBreak();
-            }
+            break;
         }
     }
 
-    m_cbSpillOver = 0;
     m_bisk = BISK_Nil;
-    m_pbRaw = 0x0;
-    m_pb = 0x0;
+    m_pbRaw = 0;
+    m_pb = 0;
     m_cbRaw = 0;
     m_cb = 0;
     m_grfDecomp = 0;
-    return;
+    m_cbSpillOver = 0;
 }
-
-#endif
 
 void CBinaryInputStream::DecrementCdReadLimit(int cb)
 {
@@ -117,13 +110,13 @@ INCLUDE_ASM(const s32, "P2/bis", PumpHost__18CBinaryInputStream);
 
 void CBinaryInputStream::Pump()
 {
-    switch(this->m_bisk)
+    switch(m_bisk)
     {
         case BISK_Host:
-            this->PumpHost();
+            PumpHost();
             break;
         case BISK_Cd:
-            this->PumpCd();
+            PumpCd();
             break;
         default:
             break;
@@ -132,15 +125,15 @@ void CBinaryInputStream::Pump()
     // FIXME: This code matches perfectly, but it could look much better.
     // I am pretty sure that m_cbRemaining is actually a pointer
     // or the value at offset 0x24 is an integer.
-    int iVar1 = this->m_cbRemaining - *(int *)((uint8_t *)this + 0x24);
+    int iVar1 = m_cbRemaining - *(int *)((uint8_t *)this + 0x24);
     int zero = 0;
     int remain = (iVar1 > zero) ? iVar1 : 0;
 
-    this->m_cbRemaining = remain;
+    m_cbRemaining = remain;
 
-    if(this->m_pprog)
+    if(m_pprog)
     {
-        this->m_pprog->SetRemain(remain);
+        m_pprog->SetRemain(remain);
     }
 }
 

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -129,7 +129,7 @@ void CBinaryInputStream::Pump()
             break;
     }
 
-    // FIXME: This code matches perfectly, but it look much better.
+    // FIXME: This code matches perfectly, but it could look much better.
     // I am pretty sure that m_cbRemaining is actually a pointer
     // or the value at offset 0x24 is an integer.
     int iVar1 = this->m_cbRemaining - *(int *)((uint8_t *)this + 0x24);

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -115,7 +115,34 @@ INCLUDE_ASM(const s32, "P2/bis", PumpCd__18CBinaryInputStream);
 
 INCLUDE_ASM(const s32, "P2/bis", PumpHost__18CBinaryInputStream);
 
-INCLUDE_ASM(const s32, "P2/bis", Pump__18CBinaryInputStream);
+void CBinaryInputStream::Pump()
+{
+    switch(this->m_bisk)
+    {
+        case BISK_Host:
+            this->PumpHost();
+            break;
+        case BISK_Cd:
+            this->PumpCd();
+            break;
+        default:
+            break;
+    }
+
+    // FIXME: This code matches perfectly, but it look much better.
+    // I am pretty sure that m_cbRemaining is actually a pointer
+    // or the value at offset 0x24 is an integer.
+    int iVar1 = this->m_cbRemaining - *(int *)((uint8_t *)this + 0x24);
+    int zero = 0;
+    int remain = (iVar1 > zero) ? iVar1 : 0;
+
+    this->m_cbRemaining = remain;
+
+    if(this->m_pprog)
+    {
+        this->m_pprog->SetRemain(remain);
+    }
+}
 
 INCLUDE_ASM(const s32, "P2/bis", Decompress__18CBinaryInputStream);
 

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -78,11 +78,11 @@ void CBinaryInputStream::Close()
             if(*(int *)((uint8_t *)this + 0x3c))
             {
                 if(m_grfbis & 0x2)
-    			{
+                {
                     sceCdBreak();
                 }
-    			else
-    			{
+                else
+                {
                     snd_StreamSafeCdBreak();
                 }
             }

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -353,6 +353,14 @@ INCLUDE_ASM(const s32, "P2/bis", ReadBspc__18CBinaryInputStreamP4GEOMP4BSPC);
 
 INCLUDE_ASM(const s32, "P2/bis", ReadVbsp__18CBinaryInputStreamPiPP4VBSP);
 
-INCLUDE_ASM(const s32, "P2/bis", ReadStringSw__18CBinaryInputStreamPPc);
+void CBinaryInputStream::ReadStringSw(char **pachz)
+{
+    uint16_t length = U16Read();
+    char *buffer = (char *)PvAllocSwImpl((int)length + 1);
+    Read((int)length, buffer);
+    buffer[length] = 0;
+    *pachz = buffer;
+}
+
 INCLUDE_ASM(const s32, "P2/bis", func_00138510);
 INCLUDE_ASM(const s32, "P2/bis", func_00138550);

--- a/src/P2/gs.c
+++ b/src/P2/gs.c
@@ -33,15 +33,10 @@ uint NLog2(uint value)
     uint log2 = 0;
     uint bit = 1;
 
-    if(bit < value)
+    while (bit < value && log2 < 31)
     {
-        do
-        {
-            bit <<= 1;
-            log2++;
-            if(!(bit < value) || log2 >= 31)
-                break;
-        } while(true);
+        bit <<= 1;
+        log2++;
     }
 
     return log2;

--- a/src/P2/gs.c
+++ b/src/P2/gs.c
@@ -28,7 +28,24 @@ INCLUDE_ASM(const s32, "P2/gs", FadeFramesToBlack__Ff);
 
 INCLUDE_ASM(const s32, "P2/gs", ResetGsMemory__Fv);
 
-INCLUDE_ASM(const s32, "P2/gs", NLog2__FUi);
+uint NLog2(uint value)
+{
+    uint log2 = 0;
+    uint bit = 1;
+
+    if(bit < value)
+    {
+        do
+        {
+            bit <<= 1;
+            log2++;
+            if(!(bit < value) || log2 >= 31)
+                break;
+        } while(true);
+    }
+
+    return log2;
+}
 
 void InitGsb(GSB *pgsb, int igsMin, int igsMax)
 {

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -52,14 +52,23 @@ extern "C" int sprintf(char *pchzDest, char *pchzFormat, ...)
 INCLUDE_ASM(const s32, "P2/text", _vsnprintf);
 INCLUDE_ASM(const s32, "P2/text", func_001E20B0);
 
-INCLUDE_ASM(const s32, "P2/text", _snprintf);
+int _snprintf(char *pchzDest, int cchDest, char *pchzFormat, ...)
+{
+    va_list arg;
+    va_start(arg, pchzFormat);
+    int ret = _vsnprintf(pchzDest, cchDest, pchzFormat, arg);
+    va_end(arg);
+    return ret;
+}
+
 INCLUDE_ASM(const s32, "P2/text", func_001E20F8);
 
 extern "C" uint strlen(const char *pchz)
 {
     uint len = 0;
 
-    while(*pchz != '\0') {
+    while(*pchz != '\0')
+	{
         pchz++;
         len++;
     }

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -30,7 +30,8 @@ INCLUDE_ASM(const s32, "P2/text", CchOstrmPrintf__FP5OSTRMPcT1);
 
 INCLUDE_ASM(const s32, "P2/text", vprintf);
 
-extern "C" int printf(char *pchzFormat, ...) {
+extern "C" int printf(char *pchzFormat, ...)
+{
     va_list arg;
     va_start(arg, pchzFormat);
     int ret = vprintf(pchzFormat, arg);
@@ -68,7 +69,7 @@ extern "C" uint strlen(const char *pchz)
     uint len = 0;
 
     while(*pchz != '\0')
-	{
+    {
         pchz++;
         len++;
     }

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -1,5 +1,6 @@
 #include <text.h>
 #include <memory.h>
+#include <stdarg.h>
 
 INCLUDE_ASM(const s32, "P2/text", CchParsePchzInt__FPcPi);
 
@@ -29,7 +30,13 @@ INCLUDE_ASM(const s32, "P2/text", CchOstrmPrintf__FP5OSTRMPcT1);
 
 INCLUDE_ASM(const s32, "P2/text", vprintf);
 
-INCLUDE_ASM(const s32, "P2/text", printf);
+extern "C" int printf(char *format, ...) {
+    va_list arg;
+    va_start(arg, format);
+    int ret = vprintf(format, arg);
+    va_end(arg);
+    return ret;
+}
 
 INCLUDE_ASM(const s32, "P2/text", vsprintf);
 

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -30,17 +30,24 @@ INCLUDE_ASM(const s32, "P2/text", CchOstrmPrintf__FP5OSTRMPcT1);
 
 INCLUDE_ASM(const s32, "P2/text", vprintf);
 
-extern "C" int printf(char *format, ...) {
+extern "C" int printf(char *pchzFormat, ...) {
     va_list arg;
-    va_start(arg, format);
-    int ret = vprintf(format, arg);
+    va_start(arg, pchzFormat);
+    int ret = vprintf(pchzFormat, arg);
     va_end(arg);
     return ret;
 }
 
 INCLUDE_ASM(const s32, "P2/text", vsprintf);
 
-INCLUDE_ASM(const s32, "P2/text", sprintf);
+extern "C" int sprintf(char *pchzDest, char *pchzFormat, ...)
+{
+    va_list arg;
+    va_start(arg, pchzFormat);
+    int ret = vsprintf(pchzDest, pchzFormat, arg);
+    va_end(arg);
+    return ret;
+}
 
 INCLUDE_ASM(const s32, "P2/text", _vsnprintf);
 INCLUDE_ASM(const s32, "P2/text", func_001E20B0);
@@ -60,18 +67,18 @@ extern "C" uint strlen(const char *pchz)
     return len;
 }
 
-extern "C" char *strcpy(char *dst, const char *src)
+extern "C" char *strcpy(char *pchzDst, const char *pchzSrc)
 {
-    CopyAb(dst, (char *)src, strlen(src) + 1);
-    return dst;
+    CopyAb(pchzDst, (char *)pchzSrc, strlen(pchzSrc) + 1);
+    return pchzDst;
 }
 
-extern "C" char *strcpy1(char *dst, char *src)
+extern "C" char *strcpy1(char *pchzDst, char *pchzSrc)
 {
-    uint dstLength = strlen(dst);
-    uint srcLength = strlen(src);
-    CopyAb(dst + dstLength, src, srcLength + 1);
-    return dst;
+    uint dstLength = strlen(pchzDst);
+    uint srcLength = strlen(pchzSrc);
+    CopyAb(pchzDst + dstLength, pchzSrc, srcLength + 1);
+    return pchzDst;
 }
 
 extern "C" char *strchr(char *pchz, int ch)

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -1,4 +1,5 @@
 #include <text.h>
+#include <memory.h>
 
 INCLUDE_ASM(const s32, "P2/text", CchParsePchzInt__FPcPi);
 
@@ -52,7 +53,11 @@ extern "C" uint strlen(const char *pchz)
     return len;
 }
 
-INCLUDE_ASM(const s32, "P2/text", strcpy);
+extern "C" char *strcpy(char *dst, const char *src)
+{
+    CopyAb(dst, (char *)src, strlen(src) + 1);
+    return dst;
+}
 
 INCLUDE_ASM(const s32, "P2/text", strcpy1);
 

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -59,7 +59,6 @@ extern "C" char *strcpy(char *dst, const char *src)
     return dst;
 }
 
-// INCLUDE_ASM(const s32, "P2/text", strcpy1);
 extern "C" char *strcpy1(char *dst, char *src)
 {
     uint dstLength = strlen(dst);

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -59,7 +59,14 @@ extern "C" char *strcpy(char *dst, const char *src)
     return dst;
 }
 
-INCLUDE_ASM(const s32, "P2/text", strcpy1);
+// INCLUDE_ASM(const s32, "P2/text", strcpy1);
+extern "C" char *strcpy1(char *dst, char *src)
+{
+    uint dstLength = strlen(dst);
+    uint srcLength = strlen(src);
+    CopyAb(dst + dstLength, src, srcLength + 1);
+    return dst;
+}
 
 extern "C" char *strchr(char *pchz, int ch)
 {


### PR DESCRIPTION
I've managed to fully match `CBinaryInputStream::Close()`, but there are a few fields that get accessed with their addresses. I suspect that `m_tickWait` doesn't exist, but I am not sure.

I also added a cleaned up version of `NLog2` from [a scratch](https://decomp.me/scratch/hHtJm) by @Mc-muffin, that was based on [my scratch](https://decomp.me/scratch/z91UK).