### PR TITLE
Matched RemoveDlelement().

### DIFF
--- a/include/dl.h
+++ b/include/dl.h
@@ -20,7 +20,10 @@ struct DL
 };
 
 /**
- * Doubly Linked list Element
+ * @brief Doubly Linked list Element
+ *
+ * @param next Points to the next element in the chain.
+ * @param prev Points to the previous element in the chain.
  */
 struct DLE
 {
@@ -29,7 +32,12 @@ struct DLE
 };
 
 /**
- * @brief Unknown.
+ * @brief Doubly Linked-list Iterator. Used to iterate through DLs in the global list (Singly Linked-list).
+ * 
+ * @param m_pdl The actual doubly linked list the iterator is navigating.
+ * @param m_ppv A pointer to the current element/node inside that list.
+ * @param m_ibDle Offset the the DLE structure.
+ * @param m_pdliNext Next DLI in the chain.
  */
 struct DLI
 {
@@ -113,7 +121,7 @@ void PrependDlEntry(DL *pdl, void *pv);
 void InsertDlEntryBefore(DL *pdl, void *pvNext, void *pv);
 
 /**
- * @brief Remove an element from the doubly linked list.
+ * @brief Remove an element from the doubly linked list and manage the doubly linked list iterator, incase the element being removed is a current iterator for an DLI instance.
  *
  * @param pdl Doubly linked list to remove the element from.
  * @param pv Element to remove.

--- a/src/P2/dl.c
+++ b/src/P2/dl.c
@@ -1,5 +1,8 @@
 #include <dl.h>
 
+extern void *D_0027B314; // global iterator list (DLI::s_pdliFirst)
+#define s_pdliFirst (*(DLI**)&D_0027B314)
+
 void InitDl(DL *pdl, int ibDle)
 {
     pdl->ibDle = ibDle;
@@ -78,9 +81,77 @@ void InsertDlEntryBefore(DL *pdl, void *pvNext, void *pv)
     }
 }
 
+//  Pretty sure this is a STUB func. Asm shows the function is void and empty. -Zryu
 INCLUDE_ASM(const s32, "P2/dl", func_001525F8);
 
-INCLUDE_ASM(const s32, "P2/dl", RemoveDlEntry__FP2DLPv);
+void RemoveDlEntry(DL* pdl, void* pv)
+{
+
+    DLE* pentry;
+    DLI* pcurrent;
+    void* pprev;
+    DLE* ptemp;
+
+    pentry = PdleFromDlEntry(pdl, pv);
+    pcurrent = s_pdliFirst; 
+
+    // Loop through global iterator list to find DLI that houses the DLE we're looking for.
+    while (pcurrent != nullptr)
+    {
+
+        if ((DLE *)pcurrent->m_ppv == pentry)
+        {
+
+            // If the DLE is the current index of the DLI, replace the with prev.
+            pprev = pentry->prev;
+            if (pprev != nullptr)
+            {
+
+                ptemp = PdleFromDlEntry(pdl, pprev);
+                (DLE *)pcurrent->m_ppv = ptemp;
+            }
+            else
+            {
+
+                (DLE *)pcurrent->m_ppv = pdl;
+            }
+        }
+
+        pcurrent = pcurrent->m_pdliNext;
+    }
+
+    // Adjust head
+    pprev = pentry->prev;
+    if (pprev != nullptr)
+    {
+
+        ptemp = PdleFromDlEntry(pdl, pprev);
+        ptemp->next = pentry->next;
+    }
+    else
+    {
+
+        pdl->head = pentry->next;
+    }
+
+    // Adjust tail
+    pprev = pentry->next;
+    if (pprev != nullptr)
+    {
+
+        ptemp = PdleFromDlEntry(pdl, pprev);
+        ptemp->prev = pentry->prev;
+    }
+    else
+    {
+
+        pdl->tail = pentry->prev;
+    }
+
+    // Clear links
+    pentry->next = nullptr;
+    pentry->prev = nullptr;
+}
 
 bool FFindDlEntry(DL *pdl, void *pv)
 {


### PR DESCRIPTION
In dl.h - updated DLI, DLE and RemoveDlEntry() comments to better explain structs/functions. Added extern to s_pdliFirst static pointer (D_0027B314) and macro'd it to 's_pdliFirst' keep up with whats shown in the source code.

I left comments in the function and above the last INCLUDE_ASM functions as I wasnt sure if we should keep them or not. Let me know if I need to remove them.

Checksum ok and matched asm https://decomp.me/scratch/nrbde.