### PR TITLE
Populated structs, Enums and Matched SetCharmDprizes() in coin.c.

### DIFF
--- a/include/coin.h
+++ b/include/coin.h
@@ -12,6 +12,7 @@
 #include <sm.h>
 #include <sw.h>
 #include <xform.h>
+#include <sound.h>
 
 // Forward declarations
 struct DPRIZE;
@@ -97,7 +98,12 @@ struct COIN : public DPRIZE
  */
 struct KEY : public DPRIZE
 {
-    // ...
+    uint8_t unk_uint8_pad[0x14];         // 0x0 - 0x13 Padding?
+    SW* psw;                             // 0x14
+    uint8_t unk_uint8_pad1[0x2b - 0x18]; // 0x18-0x2b Pading?
+    CFrame* pcframe;                     // 0x2c
+    uint8_t unk_uint_pad2[0x2cf - 0x31]; // 0x31 - 0x2cf Padding?
+    DPRIZES dprizes;                     // 0x2d0
 };
 
 /**
@@ -105,6 +111,7 @@ struct KEY : public DPRIZE
  */
 struct CHARM : public DPRIZE
 {
+
 };
 
 /**
@@ -131,6 +138,16 @@ void LoadDprizeFromBrx(DPRIZE *pdprize, CBinaryInputStream *pbis);
  * @note ichkCollected and dle will not be overwritten
  */
 void CloneDprize(DPRIZE *pdprize, DPRIZE *pdprizeBase);
+
+/**
+ * @brief Sets the DPRIZES enum of a given DPRIZE.
+ *
+ * @param pdprize DPRIZE whose enum needs to be set.
+ * @param dprizes New DPRIZES value.
+ *
+ * @note ichkCollected and dle will not be overwritten
+ */
+void SetDprizeDprizes(DPRIZE *pdprize, DPRIZES dprizes);
 
 /**
  * @brief Initializes a DPrize
@@ -165,14 +182,14 @@ void AddLife(void *ptr);
 void OnCoinSmack(COIN *pcoin);
 
 /**
- * @brief Sets the coin's prize.
+ * @brief Sets the coin's Dprizes enum.
  *
  * @param pcoin Pointer to the coin.
  * @param dprizes The new prize.
  *
  * @todo Implement this function.
  */
-void SetcoinDprizes(COIN *pcoin, DPRIZES dprizes);
+void SetCoinDprizes(COIN *pcoin, DPRIZES dprizes);
 
 /**
  * @brief Initializes a Charm
@@ -182,11 +199,22 @@ void SetcoinDprizes(COIN *pcoin, DPRIZES dprizes);
 void InitCharm(CHARM *pcharm);
 
 /**
+ * @brief Sets the Charm's Dprizes enum.
+ *
+ * @param pcharm Pointer to the charm.
+ * @param dprizes The new prize.
+ *
+ * @todo Fill CHARM struct.
+ */
+void SetCharmDprizes(CHARM *pcharm, DPRIZES dprizes);
+
+/**
  * @brief Initializes a Charm
  *
  * @param pcharm Charm to initialize
  */
 void InitKey(KEY *pkey);
+
 
 void SetKeyDprizes(KEY *pkey, DPRIZES dprizes);
 

--- a/include/sound.h
+++ b/include/sound.h
@@ -10,11 +10,56 @@
 #include <util.h>
 #include <alo.h>
 
+/**
+ * @brief SFX ID. 
+ */
 enum SFXID
 {
-    SFXID_UiTick = 0, // inaccurate
-    // ...
-
+    SFXID_click1 = 2,
+    SFXID_swoosh = 3,
+    SFXID_JtFootfall1 = 4,
+    SFXID_JtFootfall2 = 5,
+    SFXID_JtFootfall3 = 6,
+    SFXID_JtFootfall4 = 7,
+    SFXID_EnvCaneReach1 = 8,
+    SFXID_EnvCaneReach2 = 9,
+    SFXID_EnvCaneReach3 = 10,
+    SFXID_cane_attack1 = 11,
+    SFXID_EnvDartsHit = 12,
+    SFXID_CaneHandleLock = 13,
+    SFXID_fire = 19,
+    SFXID_thud1 = 20,
+    SFXID_EnvAlarmSounding = 21,
+    SFXID_EnvCricketChirp = 22,
+    SFXID_splash = 22, // note: same value as EnvCricketChirp....No idea why theres a dupe.
+    SFXID_AmbElectric = 27,
+    SFXID_ripoff_something = 35,
+    SFXID_env_holographic_marker = 40,
+    SFXID_bottle_break = 44,
+    SFXID_darts_fire = 51,
+    SFXID_EnvDartsHi = 52,
+    SFXID_roc_hit = 55,
+    SFXID_blaster_fire = 58,
+    SFXID_npc_whistle = 63,
+    SFXID_jt_land = 73,
+    SFXID_collect_life = 105,
+    SFXID_last_clue = 106,
+    SFXID_yipee = 109,
+    SFXID_binoc_hum = 112,
+    SFXID_binoc_zoom = 113,
+    SFXID_click2 = 115,
+    SFXID_collect_charm = 116,
+    SFXID_sneaky_footstep = 119,
+    SFXID_collect_coin = 120,
+    SFXID_click3 = 121,
+    SFXID_click4 = 122,
+    SFXID_thud7 = 123,
+    SFXID_take_out_binoc = 142,
+    SFXID_put_away_binoc = 143,
+    SFXID_jt_hurt = 163,
+    SFXID_ripoff_hit = 335,
+    SFXID_honk = 337,
+    SFXID_ricochet = 338
 };
 
 /**

--- a/src/P2/coin.c
+++ b/src/P2/coin.c
@@ -146,6 +146,23 @@ void InitCharm(CHARM *pcharm)
 }
 
 INCLUDE_ASM(const s32, "P2/coin", SetCharmDprizes__FP5CHARM7DPRIZES);
+#ifdef SKIP_ASM
+/** @todo 99% matched. 
+ *        Requires CHARM struct to be filled out and StartSound() to continue.
+ *        https://decomp.me/scratch/2Mb5l. -Zryu
+ */
+void SetCharmDprizes(CHARM *pcharm, DPRIZES dprizes) {
+    if (pcharm->dprizes != dprizes) {
+        if (dprizes == DPRIZES_Collect) {
+            dprizes = DPRIZES_Swirl;
+            StartSound(SFXID_collect_charm, (AMB **)0x0, pcharm, (VECTOR *) 0x0,
+                       1500.0f, 0.0f,1, 0.0f, 0.0f, (LM *)0x0, (LM *)0x0);
+            HandleLoSpliceEvent(pcharm, 2, 0, 0);
+        }
+        SetDprizeDprizes(pcharm, dprizes);
+    }
+}
+#endif
 
 void InitKey(KEY *pkey)
 {


### PR DESCRIPTION
Populated KEY struct, renamed SetcoinDprize to SetCoinDprize, and added sound.h as an include in coin.h.
Populated SFXID enum in sound.h.
Matched SetCharmDprizes() to 99.88%. The last 1% is because its accessing a DPRIZES member unknown to us in CHARM struct. It also can't be added until StartSound() is implemented (more info in coin.c).