### PR TITLE
Split P2/memory and match some functions

### DIFF
--- a/config/sly1.yaml
+++ b/config/sly1.yaml
@@ -168,7 +168,7 @@ segments:
     - [0x8b388, asm, P2/mecha]
     #- [0x, asm, P2/mb]
     #- [0x, asm, P2/memcard]
-    - [0x8e4b0, asm, P2/memory]
+    - [0x8e4b0, c, P2/memory]
     - [0x8e8e0, asm, P2/missile]
     #- [0x, asm, P2/mouthgame]
     #- [0x, asm, P2/mpeg]

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -5,8 +5,6 @@
 _start = 0x100008; // type:func
 _exit = 0x1000B8; // type:func
 
-__builtin_delete = 0x18d778; // type:func
-
 _gpReg = 0x2832F0;
 
 g_chzCiphertext = 0x2483b8; // size:0x9
@@ -1226,8 +1224,23 @@ g_apchzArgs = 0x264838; // size:0x4
 // P2/memory.c
 ////////////////////////////////////////////////////////////////
 PvAllocGlobalImpl__Fi = 0x18D4B0; // type:func
-PvAllocSwImpl__Fl = 0x18d500; // type:func
-CopyAb__FPvT0Ui = 0x18d800; // type:func
+func_0018D4F0 = 0x18D4F0; // type:func
+func_0018D4F8__Fv = 0x18D4F8; // type:func
+PvAllocSwImpl__FUi = 0x18D500; // type:func
+func_0018D550 = 0x18D550; // type:func
+PvAllocSwCopyImpl__FUiPv = 0x18D568; // type:func
+PvAllocSwClearImpl__FUi = 0x18D5C0; // type:func
+func_0018D608 = 0x18D608; // type:func
+func_0018D658 = 0x18D658; // type:func
+func_0018D6A8 = 0x18D6A8; // type:func
+func_0018D6F0 = 0x18D6F0; // type:func
+func_0018D740 = 0x18D740; // type:func
+func_0018D748 = 0x18D748; // type:func
+func_0018D750__Fv = 0x18D750; // type:func
+func_0018D758__FUi = 0x18D758; // type:func
+__builtin_delete = 0x18D778; // type:func
+func_0018D780 = 0x18D780; // type:func
+CopyAb__FPvT0Ui = 0x18D800; // type:func
 
 
 ////////////////////////////////////////////////////////////////

--- a/include/memory.h
+++ b/include/memory.h
@@ -7,6 +7,28 @@
 #include "common.h"
 
 /**
+ * @brief Allocate a block of memory.
+ *
+ * @param cb Size of the block in bytes.
+ */
+void *PvAllocSwImpl(uint cb);
+
+/**
+ * @brief Allocate a block of memory and copy data to it from the given pointer.
+ *
+ * @param cb Size of the block in bytes.
+ * @param pvSrc Data to copy.
+ */
+void *PvAllocSwCopyImpl(uint cb, void *pvSrc);
+
+/**
+ * @brief Allocate a block of memory and clear it.
+ *
+ * @param cb Size of the block in bytes.
+ */
+void *PvAllocSwClearImpl(uint cb);
+
+/**
  * @brief Copies a block of memory from one location to another.
  *
  * @param pvDst Pointer to the destination memory location.
@@ -14,12 +36,5 @@
  * @param cb Number of bytes to copy.
  */
 void CopyAb(void *pvDst, void *pvSrc, uint cb);
-
-/**
- * @brief Allocate a block of memory.
- *
- * @param size Size of the block in bytes.
- */
-void *PvAllocSwImpl(long size);
 
 #endif // MEMORY_H

--- a/src/P2/memory.c
+++ b/src/P2/memory.c
@@ -1,0 +1,77 @@
+#include <memory.h>
+#include <sce/memset.h>
+
+INCLUDE_ASM(const s32, "P2/memory", PvAllocGlobalImpl__Fi);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D4F0);
+
+/**
+ * @todo Rename function.
+ */
+void func_0018D4F8()
+{
+    return;
+}
+
+INCLUDE_ASM(const s32, "P2/memory", PvAllocSwImpl__FUi);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D550);
+
+void *PvAllocSwCopyImpl(uint cb, void *pvSrc)
+{
+    void *pvDst = PvAllocSwImpl(cb);
+    if (pvDst)
+    {
+        CopyAb(pvDst, pvSrc, cb);
+    }
+    
+    return pvDst;
+}
+
+void *PvAllocSwClearImpl(uint cb)
+{
+    void *pvBlock = PvAllocSwImpl(cb);
+    if(pvBlock)
+    {
+        memset(pvBlock, 0, cb);
+    }
+    
+    return pvBlock;
+}
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D608);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D658);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D6A8);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D6F0);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D740);
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D748);
+
+/**
+ * @todo Rename function.
+ */
+void func_0018D750()
+{
+    return;
+}
+
+/**
+ * @todo Rename function.
+ */
+void *func_0018D758(uint cb)
+{
+    return PvAllocSwClearImpl(cb);
+}
+
+void __builtin_delete()
+{
+    return;
+}
+
+INCLUDE_ASM(const s32, "P2/memory", func_0018D780);
+
+INCLUDE_ASM(const s32, "P2/memory", CopyAb__FPvT0Ui);


### PR DESCRIPTION
I splitted `P2/memory.c` and matched a few functions in it. For some reason it contains a few stub functions? Might be leftovers from during earlier in the development?