### PR TITLE
Split P2/act and match a few functions

### DIFF
--- a/config/sly1.yaml
+++ b/config/sly1.yaml
@@ -83,7 +83,7 @@ segments:
     - [0x1dbb8, c, P2/989snd] #MARK: P2
     - [0x1f560, c, P2/brx]
     - [0x1fe70, c, P2/ac]
-    - [0x22228, asm, P2/act]
+    - [0x22228, c, P2/act]
     - [0x23f28, c, P2/actseg]
     - [0x243c0, c, P2/alarm]
     - [0x24dc0, c, P2/alo]

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -546,7 +546,46 @@ PacgNew__F4ACGK                                        = 0x121160; // type:func
 ////////////////////////////////////////////////////////////////
 // P2/act.c
 ////////////////////////////////////////////////////////////////
-PactNew__FP2SWP3ALOP5VTACT = 0x121228;
+PactNew__FP2SWP3ALOP5VTACT                             = 0x121228; // type:func
+PactNewClone__FP3ACTP2SWP3ALO                          = 0x121280; // type:func
+CloneAct__FP3ACTT0                                     = 0x1212D8; // type:func
+InitAct__FP3ACTP3ALO                                   = 0x121338; // type:func
+RetractAct__FP3ACTi                                    = 0x121358; // type:func
+GetActPositionGoal__FP3ACTfP6VECTORT2                  = 0x1214B8; // type:func
+GetActRotationGoal__FP3ACTfP7MATRIX3P6VECTOR           = 0x121508; // type:func
+GetActTwistGoal__FP3ACTPfT1                            = 0x121568; // type:func
+GetActScale__FP3ACTP7MATRIX3                           = 0x121580; // type:func
+GGetActPoseGoal__FP3ACTi                               = 0x1215A8; // type:func
+CalculateActDefaultAck__FP3ACT                         = 0x1215C0; // type:func
+SnapAct__FP3ACTi                                       = 0x121648; // type:func
+CalculateAloPositionSpring__FP3ALOfP6VECTORN22         = 0x121760; // type:func
+ProjectActPosition__FP3ACT                             = 0x1218C0; // type:func
+CalculateAloRotationSpring__FP3ALOfP7MATRIX3P6VECTORT3 = 0x121C48; // type:func
+ProjectActRotation__FP3ACT                             = 0x121DE0; // type:func
+ProjectActPose__FP3ACTi                                = 0x122488; // type:func
+PredictAloPosition__FP3ALOfP6VECTORT2                  = 0x122550; // type:func
+PredictAloRotation__FP3ALOfP7MATRIX3P6VECTOR           = 0x1225D0; // type:func
+AdaptAct__FP3ACT                                       = 0x1226D8; // type:func
+InitActval__FP6ACTVALP3ALO                             = 0x122708; // type:func
+GetActvalPositionGoal__FP6ACTVALfP6VECTORT2            = 0x1227B0; // type:func
+GetActvalRotationGoal__FP6ACTVALfP7MATRIX3P6VECTOR     = 0x1227F0; // type:func
+GetActvalTwistGoal__FP6ACTVALPfT1                      = 0x122840; // type:func
+GetActvalScale__FP6ACTVALP7MATRIX3                     = 0x122858; // type:func
+GGetActvalPoseGoal__FP6ACTVALi                         = 0x122878; // type:func
+InitActref__FP6ACTREFP3ALO                             = 0x122890; // type:func
+GetActrefPositionGoal__FP6ACTREFfP6VECTORT2            = 0x122920; // type:func
+GetActrefRotationGoal__FP6ACTREFfP7MATRIX3P6VECTOR     = 0x122968; // type:func
+GetActrefTwistGoal__FP6ACTREFPfT1                      = 0x1229C0; // type:func
+GetActrefScale__FP6ACTREFP7MATRIX3                     = 0x1229E0; // type:func
+GGetActrefPoseGoal__FP6ACTREFi                         = 0x122A00; // type:func
+InitActadj__FP6ACTADJP3ALO                             = 0x122A18; // type:func
+GetActadjPositionGoal__FP6ACTADJfP6VECTORT2            = 0x122A80; // type:func
+GetActadjRotationGoal__FP6ACTADJfP7MATRIX3P6VECTOR     = 0x122B30; // type:func
+GetActadjTwistGoal__FP6ACTADJPfT1                      = 0x122C48; // type:func
+GetActadjScale__FP6ACTADJP7MATRIX3                     = 0x122CB0; // type:func
+GGetActadjPoseGoal__FP6ACTADJi                         = 0x122D90; // type:func
+InitActbank__FP7ACTBANKP3ALO                           = 0x122DA0; // type:func
+GetActbankRotationGoal__FP7ACTBANKfP7MATRIX3P6VECTOR   = 0x122DE0; // type:func
 
 
 ////////////////////////////////////////////////////////////////

--- a/include/act.h
+++ b/include/act.h
@@ -1,20 +1,157 @@
+/**
+ * @file act.h
+ */
 #ifndef ACT_H
 #define ACT_H
 
 #include "common.h"
+#include <vec.h>
+#include <mat.h>
+#include <dl.h>
 
 // Forward.
 struct SW;
 struct ALO;
 
+typedef int GRFRA;
+
 /**
- * @brief TODO
+ * @brief Unknown.
+ * @todo Implement the struct.
  */
 struct ACT
+{
+    /* 0x00 */ STRUCT_PADDING(1); // TODO: Add vtables
+    /* 0x04 */ ALO *palo;
+    /* 0x08 */ DLE dleAlo;
+    /* 0x10 */ STRUCT_PADDING(1);
+    /* 0x14 */ int nPriority;
+    /* 0x18 */ float tMatch;
+};
+
+/**
+ * @brief Unknown.
+ * @todo Implement the struct.
+ */
+struct ACTVAL : public ACT
+{
+    /* 0x1c */ STRUCT_PADDING(25);
+    /* 0x80 */ float radTwistGoal;
+    /* 0x84 */ float dradTwistGoal;
+    /* 0x88 */ STRUCT_PADDING(15);
+    /* 0xc4 */ float *agPoses;
+    // ...
+};
+
+/**
+ * @brief Unknown.
+ * @todo Implement the struct.
+ */
+struct ACTREF : public ACT
+{
+    /* 0x1c */ STRUCT_PADDING(4);
+    /* 0x2c */ float *pradTwistGoal;
+    /* 0x30 */ float *pdradTwistGoal;
+    // ...
+};
+
+/**
+ * @brief Unknown.
+ * @todo Implement the struct.
+ */
+struct ACTADJ : public ACT
 {
     // ...
 };
 
+/**
+ * @brief Unknown.
+ * @todo Implement the struct.
+ */
+struct ACTBANK : public ACT
+{
+    /* 0x1c */ float uBank;
+    /* 0x20 */ float dtPredict;
+};
+
 ACT *PactNew(SW *psw, ALO *palo, VTACT *pvtact);
+
+ACT *PactNewClone(ACT *pactBase, SW *psw, ALO *palo);
+
+void CloneAct(ACT *pact, ACT *pactBase);
+
+void InitAct(ACT *pact, ALO *palo);
+
+void RetractAct(ACT *pact, GRFRA grfra);
+
+void GetActPositionGoal(ACT *pact, float dtOffset, VECTOR *ppos, VECTOR *pv);
+
+void GetActRotationGoal(ACT *pact, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
+
+void GetActTwistGoal(ACT *pact, float *pradTwist, float *pdradTwist);
+
+void GetActScale(ACT *pact, MATRIX3 *pmat);
+
+float GGetActPoseGoal(ACT *pact, int ipose);
+
+void CalculateActDefaultAck(ACT *pact);
+
+void SnapAct(ACT *pact, int fForce);
+
+void CalculateAloPositionSpring(ALO *palo, float dt, VECTOR *pposGoal, VECTOR *pvGoal, VECTOR *pdv);
+
+void ProjectActPosition(ACT *pact);
+
+void CalculateAloRotationSpring(ALO *palo, float dt, MATRIX3 *pmatGoal, VECTOR *pwGoal, VECTOR *pdw);
+
+void ProjectActRotation(ACT *pact);
+
+void ProjectActPose(ACT *pact, int ipose);
+
+void PredictAloPosition(ALO *palo, float dtOffset, VECTOR *ppos, VECTOR *pv);
+
+void PredictAloRotation(ALO *palo, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
+
+void AdaptAct(ACT *pact);
+
+void InitActval(ACTVAL *pactval, ALO *palo);
+
+void GetActvalPositionGoal(ACTVAL *pactval, float dtOffset, VECTOR *ppos, VECTOR *pv);
+
+void GetActvalRotationGoal(ACTVAL *pactval, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
+
+void GetActvalTwistGoal(ACTVAL *pactval, float *pradTwist, float *pdradTwist);
+
+void GetActvalScale(ACTVAL *pactval, MATRIX3 *pmat);
+
+float GGetActvalPoseGoal(ACTVAL *pactval, int ipose);
+
+void InitActref(ACTREF *pactref, ALO *palo);
+
+void GetActrefPositionGoal(ACTREF *pactref, float dtOffset, VECTOR *ppos, VECTOR *pv);
+
+void GetActrefRotationGoal(ACTREF *pactref, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
+
+void GetActrefTwistGoal(ACTREF *pactref, float *pradTwist, float *pdradTwist);
+
+void GetActrefScale(ACTREF *pactref, MATRIX3 *pmat);
+
+float GGetActrefPoseGoal(ACTREF *pactref, int ipose);
+
+void InitActadj(ACTADJ *pactadj, ALO *palo);
+
+void GetActadjPositionGoal(ACTADJ *pactadj, float dtOffset, VECTOR *ppos, VECTOR *pv);
+
+void GetActadjRotationGoal(ACTADJ *pactadj, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
+
+void GetActadjTwistGoal(ACTADJ *pactadj, float *pradTwist, float *pdradTwist);
+
+void GetActadjScale(ACTADJ *pactadj, MATRIX3 *pmat);
+
+float GGetActadjPoseGoal(ACTADJ *pactadj, int ipose);
+
+void InitActbank(ACTBANK *pactbank, ALO *palo);
+
+void GetActbankRotationGoal(ACTBANK *pactbank, float dtOffset, MATRIX3 *pmat, VECTOR *pw);
 
 #endif // ACT_H

--- a/include/stepact.h
+++ b/include/stepact.h
@@ -5,17 +5,7 @@
 #define STEPACT_H
 
 #include "common.h"
-#include <vec.h>
-#include <mat.h>
-
-/**
- * @brief Unknown.
- * @todo Should this be defined here?
- */
-struct ACT
-{
-    // ...
-};
+#include <act.h>
 
 /**
  * @brief Unknown.

--- a/src/P2/act.c
+++ b/src/P2/act.c
@@ -1,0 +1,100 @@
+#include <act.h>
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", PactNew__FP2SWP3ALOP5VTACT);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", PactNewClone__FP3ACTP2SWP3ALO);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", CloneAct__FP3ACTT0);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", InitAct__FP3ACTP3ALO);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", RetractAct__FP3ACTi);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActPositionGoal__FP3ACTfP6VECTORT2);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActRotationGoal__FP3ACTfP7MATRIX3P6VECTOR);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActTwistGoal__FP3ACTPfT1);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActScale__FP3ACTP7MATRIX3);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GGetActPoseGoal__FP3ACTi);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", CalculateActDefaultAck__FP3ACT);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", SnapAct__FP3ACTi);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", CalculateAloPositionSpring__FP3ALOfP6VECTORN22);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", ProjectActPosition__FP3ACT);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", CalculateAloRotationSpring__FP3ALOfP7MATRIX3P6VECTORT3);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", ProjectActRotation__FP3ACT);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", ProjectActPose__FP3ACTi);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", PredictAloPosition__FP3ALOfP6VECTORT2);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", PredictAloRotation__FP3ALOfP7MATRIX3P6VECTOR);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", AdaptAct__FP3ACT);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", InitActval__FP6ACTVALP3ALO);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActvalPositionGoal__FP6ACTVALfP6VECTORT2);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActvalRotationGoal__FP6ACTVALfP7MATRIX3P6VECTOR);
+
+void GetActvalTwistGoal(ACTVAL *pactval, float *pradTwist, float *pdradTwist)
+{
+    *pradTwist = pactval->radTwistGoal;
+    *pdradTwist = pactval->dradTwistGoal;
+}
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActvalScale__FP6ACTVALP7MATRIX3);
+
+float GGetActvalPoseGoal(ACTVAL *pactval, int ipose)
+{
+    return pactval->agPoses[ipose];
+}
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", InitActref__FP6ACTREFP3ALO);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActrefPositionGoal__FP6ACTREFfP6VECTORT2);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActrefRotationGoal__FP6ACTREFfP7MATRIX3P6VECTOR);
+
+void GetActrefTwistGoal(ACTREF *pactref, float *pradTwist, float *pdradTwist)
+{
+    *pradTwist = *pactref->pradTwistGoal;
+    *pdradTwist = *pactref->pdradTwistGoal;
+}
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActrefScale__FP6ACTREFP7MATRIX3);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GGetActrefPoseGoal__FP6ACTREFi);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", InitActadj__FP6ACTADJP3ALO);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActadjPositionGoal__FP6ACTADJfP6VECTORT2);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActadjRotationGoal__FP6ACTADJfP7MATRIX3P6VECTOR);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActadjTwistGoal__FP6ACTADJPfT1);
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActadjScale__FP6ACTADJP7MATRIX3);
+
+float GGetActadjPoseGoal(ACTADJ *pactadj, int ipose)
+{
+    return 0.0f;
+}
+
+void InitActbank(ACTBANK *pactbank, ALO *palo)
+{
+    InitAct(pactbank, palo);
+    pactbank->uBank = 1.0f;
+    pactbank->dtPredict = 0.25f;
+}
+
+INCLUDE_ASM("asm/nonmatchings/P2/act", GetActbankRotationGoal__FP7ACTBANKfP7MATRIX3P6VECTOR);


### PR DESCRIPTION
I tried matching `InitAct` aswell but I couldn't make sense on what the struct fields it accessed were supposed to be. They are unnamed in the prototype and yet get accessed all over `P2/act` both in release and the prototype. No matter how I tried accessing them I couldn't get it to match.