### PR TITLE
Fix typos (progd -> prodg)

### DIFF
--- a/.github/workflows/frogress.yml
+++ b/.github/workflows/frogress.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup build environment
         run: |
           sudo apt-get install binutils-mips-linux-gnu
-          scripts/setup_progd_linux.sh
+          scripts/setup_prodg_linux.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
       - name: Run build script

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup build environment
         run: |
           sudo apt-get install binutils-mips-linux-gnu
-          scripts/setup_progd_linux.sh
+          scripts/setup_prodg_linux.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
       - name: Configure and generate report

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sudo apt-get install binutils-mips-linux-gnu
 Setup the compiler using the provided script:
 
 ```bash
-./scripts/setup_progd_linux.sh
+./scripts/setup_prodg_linux.sh
 ```
 
 <!--#### Windows
@@ -160,7 +160,7 @@ choco install 7zip
 
 2. Setup build environment:
 ```powershell
-.\scripts\setup_progd_windows.bat
+.\scripts\setup_prodg_windows.bat
 ```-->
 
 ### 5. Configure and build the project


### PR DESCRIPTION
Fixed several places where `prodg` was misspelled as `progd`, including GitHub Actions workflows which caused the CI checks to fail.