### PR TITLE
Script Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ report.json
 # Compiler
 prodg*
 tools/cc/
+tools/wibo-i686
 usr/
 
 # Splat

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ __pycache__/
 .vscode
 temp/
 *.diff
+*.AppImage

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To build the project, you will need to extract the original ELF file from your o
 Install Python 3.9 or higher, pip and venv:
 
 ```bash
-sudo apt-get install python3 python3-pip python3-venv
+sudo apt install python3 python3-pip python3-venv
 ```
 
 Create a Python environment for the project:
@@ -147,8 +147,8 @@ Install 32 bit MIPS assembler and Wine:
 
 ```bash
 sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo apt-get install binutils-mips-linux-gnu wine32
+sudo apt update
+sudo apt install binutils-mips-linux-gnu wine32
 ```
 
 > **Note:** For a lighter and faster alternative to Wine, download [`wibo-i686`](https://github.com/decompals/wibo/releases/) to the `tools` directory.
@@ -156,7 +156,7 @@ sudo apt-get install binutils-mips-linux-gnu wine32
 Install Ninja build system:
 
 ```bash
-sudo apt-get install ninja-build
+sudo apt install ninja-build
 ```
 
 Setup the compiler using the provided script:

--- a/README.md
+++ b/README.md
@@ -186,14 +186,17 @@ Running the compiled executable requires [PCSX2 2.0](https://pcsx2.net/). You mu
 
 Once you have those, and you have built the executable `SCUS_971.98`, you can run it using one of three methods:
 
-### Method 1: Run from PCSX2 GUI
+### Method 1: Autorun script
 
-1. In your PCSX2 games folder, make an alias (Linux) or symbolic link (Windows) called `SCUS_971.98.elf`, which points to the `out/SCUS_971.98` file built by this project.
-    * Note: The alias/symlink must point to `out/SCUS_971.98`, not `out/SCUS_971.98.elf`.
-2. The alias/symlink will be recognized as a game in PCSX2. Right click on it, then click `Properties... > Disc Path > Browse` and select the ISO of your game backup.
-3. Click "Close" and boot the game as normal.
+The `run.sh` script in the `scripts` directory will run the last successful build in the PCSX2 emulator. It will automatically detect PCSX2 installed via package manager, Flatpak, AppImage, or XDG Desktop entries in that order and use the first ISO found in the `disc` directory to load assets.
 
-You only have to make the alias/symlink once, and it will update every time you build the project.
+Optionally, you can specify what ISO file to use:
+
+```bash
+./scripts/run.sh /path/to/GameBackup.iso
+```
+
+To detect the PCSX2 AppImage, it must be placed in the `tools` directory, or be "Installed" via an AppImage manager utility.
 
 ### Method 2: Run from PCSX2 CLI
 
@@ -210,17 +213,14 @@ pcsx2 -elf "./out/SCUS_971.98" "/path/to/GameBackup.iso"
 * The `-elf` parameter specifies the path to the `SCUS_971.98` you built from this project. Replace the example path if necessary. The emulator will use this ELF to boot the game.
 * The last argument is the path to your game ISO. Replace the example path with the path to a backup of your own game disc. This is where the emulator will load assets from.
 
-### Method 3: Autorun script
+### Method 3: Run from PCSX2 GUI
 
-The `run.sh` script in the `scripts` directory will run the last successful build in the PCSX2 emulator. It will automatically detect PCSX2 installed via package manager, Flatpak, AppImage, or XDG Desktop entries in that order and use the first ISO found in the `disc` directory to load assets.
+1. In your PCSX2 games folder, make an alias (Linux) or symbolic link (Windows) called `SCUS_971.98.elf`, which points to the `out/SCUS_971.98` file built by this project.
+    * Note: The alias/symlink must point to `out/SCUS_971.98`, not `out/SCUS_971.98.elf`.
+2. The alias/symlink will be recognized as a game in PCSX2. Right click on it, then click `Properties... > Disc Path > Browse` and select the ISO of your game backup.
+3. Click "Close" and boot the game as normal.
 
-Optionally, you can specify what ISO file to use:
-
-```bash
-./scripts/run.sh /path/to/GameBackup.iso
-```
-
-To detect the PCSX2 AppImage, it must be placed in the `tools` directory, or be "Installed" via an AppImage manager utility.
+You only have to make the alias/symlink once, and it will update every time you build the project.
 
 ## 📁 Project Structure
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Running the compiled executable requires [PCSX2 2.0](https://pcsx2.net/). You mu
 
 Once you have those, and you have built the executable `SCUS_971.98`, you can run it using one of three methods:
 
-### Method 1: Boot from PCSX2 GUI (Recommended)
+### Method 1: Run from PCSX2 GUI
 
 1. In your PCSX2 games folder, make an alias (Linux) or symbolic link (Windows) called `SCUS_971.98.elf`, which points to the `out/SCUS_971.98` file built by this project.
     * Note: The alias/symlink must point to `out/SCUS_971.98`, not `out/SCUS_971.98.elf`.
@@ -195,7 +195,7 @@ Once you have those, and you have built the executable `SCUS_971.98`, you can ru
 
 You only have to make the alias/symlink once, and it will update every time you build the project.
 
-### Method 2: Run PCSX2 from command line
+### Method 2: Run from PCSX2 CLI
 
 To boot the elf in PCSX2 from the command line, use the following command:
 
@@ -212,7 +212,15 @@ pcsx2 -elf "./out/SCUS_971.98" "/path/to/GameBackup.iso"
 
 ### Method 3: Autorun script
 
-The `run.sh` script in the `scripts` dir will automatically rebuild the executable and run it in the PCSX2 emulator. To use it, you must first edit the script to set the `PCSX2_PATH` and `ISO_PATH` variables to the correct paths on your system.
+The `run.sh` script in the `scripts` directory will run the last successful build in the PCSX2 emulator. It will automatically detect PCSX2 installed via package manager, Flatpak, AppImage, or XDG Desktop entries in that order and use the first ISO found in the `disc` directory to load assets.
+
+Optionally, you can specify what ISO file to use:
+
+```bash
+./scripts/run.sh /path/to/GameBackup.iso
+```
+
+To detect the PCSX2 AppImage, it must be placed in the `tools` directory, or be "Installed" via an AppImage manager utility.
 
 ## 📁 Project Structure
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ New contributors are welcome to make a pull request! If you would like to help b
 
 You can quickly setup the project on Debian-based systems such as Ubuntu (or WSL) using the quickstart script. Follow these three steps to get started:
 
+> **NOTE:** You can follow along on other distros by using the [Distrobox Guide](./docs/DISTROBOX.md) to set up a Debian container.
+
 ### 1. Clone the repo
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,19 +55,32 @@ New contributors are welcome to make a pull request! If you would like to help b
 
 You can quickly setup the project on Debian-based systems such as Ubuntu (or WSL) using the quickstart script. Follow these three steps to get started:
 
-### 1. Clone the repo and run quickstart.sh
-
-Copy and run the following block of commands. It may ask for your password to install dependencies.
+### 1. Clone the repo
 
 ```bash
-git clone https://github.com/theonlyzac/sly1 && \
-cd sly1 && \
-./scripts/quickstart.sh
+git clone https://github.com/theonlyzac/sly1
+cd sly1
 ```
 
-### 2. Extract the executable from your disc
+### 2. Run quickstart
 
-Copy the file `SCUS_971.98` from your Sly 1 game disc to the `disc` directory of the project. It is needed to build.
+Run the `quickstart.sh` script in the `scripts` directory. It may ask for your password to install dependencies.
+
+You have two options to automatically extract your original game executable:
+
+- <b>Method 1:</b> Copy the NTSC-U Sly 1 game ISO to the `disc` directory and then run:
+
+  ```bash
+  ./scripts/quickstart.sh
+  ```
+
+- <b>Method 2:</b> Specify a path to the ISO:
+
+  ```bash
+  ./scripts/quickstart.sh /path/to/GameBackup.iso
+  ```
+
+Otherwise, just copy the `SCUS_971.98` file from your game disc to the `disc` directory manually.
 
 ### 3. Build the project
 
@@ -75,10 +88,9 @@ Copy the file `SCUS_971.98` from your Sly 1 game disc to the `disc` directory of
 ./scripts/build.sh
 ```
 
-If it works, you will see this:
+If the build succeeds, you will see this:
 
 ```
-[XXX/XXX] sha1sum config/checksum.sha1
 out/SCUS_971.98: OK
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ New contributors are welcome to make a pull request! If you would like to help b
 
 ## ⚡ Quickstart
 
-You can quickly setup the project on Linux (or WSL) using the quickstart script. Follow these three steps get started.
+You can quickly setup the project on Debian-based systems such as Ubuntu (or WSL) using the quickstart script. Follow these three steps to get started:
 
 ### 1. Clone the repo and run quickstart.sh
 
@@ -88,6 +88,8 @@ If you have any issues, or you prefer to set up the project manually, follow the
 
 The project can be built on Linux (or Windows using WSL). Follow the instructions below to set up the build environment.
 
+> **Note:** These instructions assume a Debian-based system such as Ubuntu. For other distributions, adapt the package manager commands and package names accordingly.
+
 ### 1. Clone the repository
 
 Clone the repo to your local machine:
@@ -103,10 +105,10 @@ To build the project, you will need to extract the original ELF file from your o
 
 ### 3. Setup Python environment
 
-If you don't have Python 3.9 or higher, install it:
+Install Python 3.9 or higher, pip and venv:
 
 ```bash
-sudo apt-get install python3 python3-pip
+sudo apt-get install python3 python3-pip python3-venv
 ```
 
 Create a Python environment for the project:
@@ -129,18 +131,17 @@ pip3 install -U -r requirements.txt
 
 ### 4. Setup build environment
 
-Setup wine:
+Install 32 bit Wine and MIPS assembler:
 
 ```bash
 sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install wine32
+sudo apt-get install wine32 binutils-mips-linux-gnu
 ```
-
-Install the MIPS assembler:
+Install Ninja build system:
 
 ```bash
-sudo apt-get install binutils-mips-linux-gnu
+sudo apt-get install ninja-build
 ```
 
 Setup the compiler using the provided script:
@@ -148,20 +149,6 @@ Setup the compiler using the provided script:
 ```bash
 ./scripts/setup_prodg_linux.sh
 ```
-
-<!--#### Windows
-
-*Prerequisites: [Chocolatey](https://chocolatey.org/install)*
-
-1. Install 7zip:
-```powershell
-choco install 7zip
-```
-
-2. Setup build environment:
-```powershell
-.\scripts\setup_prodg_windows.bat
-```-->
 
 ### 5. Configure and build the project
 
@@ -194,19 +181,22 @@ Once you have those, and you have built the executable `SCUS_971.98`, you can ru
 2. The alias/symlink will be recognized as a game in PCSX2. Right click on it, then click `Properties... > Disc Path > Browse` and select the ISO of your game backup.
 3. Click "Close" and boot the game as normal.
 
-You only have make the alias/symlink once, and it will update every time you build the project.
+You only have to make the alias/symlink once, and it will update every time you build the project.
 
 ### Method 2: Run PCSX2 from command line
 
 To boot the elf in PCSX2 from the command line, use the following command:
 
 ```bash
-pcsx2.exe -elf "C:/.../sly1/out/SCUS_971.98" "C:/.../GameBackup.iso"
+pcsx2 -elf "./out/SCUS_971.98" "/path/to/GameBackup.iso"
 ```
 
-* Replace `pcsx2.exe` with the path to your PCSX2 v2.0 executable (it will be an `.appimage` file on Linux or `.exe` file on Windows).
-* The `-elf` parameter specifies the path to the `SCUS_971.98` you built from this project. Replace `...` with the path to this project on your computer. The emulator will use this ELF to boot the game.
-* The last argument is the path to your game ISO. Replace `...` with the path to a backup of your own game disc. This is where the emulator will load assets from.
+* Replace `pcsx2` with the path to your PCSX2 executable if not found automatically:
+  * <b>AppImage:</b> Use the path to the `.appimage` file.
+  * <b>Flatpak:</b> Grant PCSX2 access to your home directory with `flatpak override --user net.pcsx2.PCSX2 --filesystem=home` or a specific directory using `--filesystem=/path/to/files`. Then use `flatpak run net.pcsx2.PCSX2` as the executable. Relative paths to the ELF and ISO files will not work, only full system paths.
+  * <b>Windows:</b> Use the path to `pcsx2.exe`.
+* The `-elf` parameter specifies the path to the `SCUS_971.98` you built from this project. Replace the example path if necessary. The emulator will use this ELF to boot the game.
+* The last argument is the path to your game ISO. Replace the example path with the path to a backup of your own game disc. This is where the emulator will load assets from.
 
 ### Method 3: Autorun script
 

--- a/README.md
+++ b/README.md
@@ -143,13 +143,16 @@ pip3 install -U -r requirements.txt
 
 ### 4. Setup build environment
 
-Install 32 bit Wine and MIPS assembler:
+Install 32 bit MIPS assembler and Wine:
 
 ```bash
 sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install wine32 binutils-mips-linux-gnu
+sudo apt-get install binutils-mips-linux-gnu wine32
 ```
+
+> **Note:** For a lighter and faster alternative to Wine, download [`wibo-i686`](https://github.com/decompals/wibo/releases/) to the `tools` directory.
+
 Install Ninja build system:
 
 ```bash

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -3618,8 +3618,8 @@ g_unkblot7 = 0x26e248; // size:0x280
 g_unkblot8 = 0x26e4e0; // size:0x280
 g_unkblot9 = 0x26e760; // size:0x280
 g_note = 0x26e9f8; // size:0x280
-g_unkblot11 = 0x26eed0; // size:0x280
-g_totals = 0x26f138; // size:0x280
+g_unkblot11 = 0x26eed0; // size:0x268
+g_totals = 0x26f138; // size:0x18
 
 // Maybe doesn't belong here?
 g_binoc = 0x2701F8; // size:0x4
@@ -4707,7 +4707,7 @@ ResetWorld__F6FTRANS = 0x1E5278; // type:func
 transition__static_initialization_and_destruction_0 = 0x1E5328; // type:func
 _GLOBAL_$I$g_transition = 0x1E5358; // type:func
 
-g_transition = 0x275af0; // size:0x54
+g_transition = 0x275af0; // size:0x38
 
 
 ////////////////////////////////////////////////////////////////

--- a/configure.py
+++ b/configure.py
@@ -37,12 +37,13 @@ COMMON_COMPILE_FLAGS = (
     f"-x c++ -B{TOOLS_DIR}/cc/lib/gcc-lib/ee/2.95.2/ -O2 -G0 -ffast-math"
 )
 
-WINE = "WINEDEBUG=-all wine"
+WIBO = TOOLS_DIR / "wibo-i686"
+WINECMD = f"{WIBO}" if WIBO.exists() else "WINEDEBUG=-all wine"
 
 COMPILE_CMD = f"{CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
 if sys.platform == "linux":
     COMPILE_CMD = (
-        f"{WINE} {CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
+        f"{WINECMD} {CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
     )
 
 CATEGORY_MAP = {

--- a/configure.py
+++ b/configure.py
@@ -2,6 +2,7 @@
 Configures the project for building. Invokes splat to split the binary and
 creates build files for ninja.
 """
+
 #! /usr/bin/env python3
 import argparse
 import os
@@ -17,7 +18,7 @@ import splat
 import splat.scripts.split as split
 from splat.segtypes.linker_entry import LinkerEntry
 
-#MARK: Constants
+# MARK: Constants
 ROOT = Path(__file__).parent.resolve()
 TOOLS_DIR = ROOT / "tools"
 OUTDIR = "out"
@@ -32,7 +33,9 @@ PRE_ELF_PATH = f"{OUTDIR}/{BASENAME}.elf"
 COMMON_INCLUDES = "-Iinclude -isystem include/sdk/ee -isystem include/gcc"
 
 CC_DIR = f"{TOOLS_DIR}/cc/bin"
-COMMON_COMPILE_FLAGS = f"-x c++ -B{TOOLS_DIR}/cc/lib/gcc-lib/ee/2.95.2/ -O2 -G0 -ffast-math"
+COMMON_COMPILE_FLAGS = (
+    f"-x c++ -B{TOOLS_DIR}/cc/lib/gcc-lib/ee/2.95.2/ -O2 -G0 -ffast-math"
+)
 
 WINE = "WINEDEBUG=-all wine"
 
@@ -49,6 +52,7 @@ CATEGORY_MAP = {
     "data": "Data",
 }
 
+
 def clean():
     """
     Clean all products of the build process.
@@ -59,7 +63,7 @@ def clean():
         "build.ninja",
         "permuter_settings.toml",
         "objdiff.json",
-        LD_PATH
+        LD_PATH,
     ]
     for filename in files_to_clean:
         if os.path.exists(filename):
@@ -76,7 +80,8 @@ def write_permuter_settings():
     Write the permuter settings file, comprising the compiler and assembler commands.
     """
     with open("permuter_settings.toml", "w", encoding="utf-8") as f:
-        f.write(f"""compiler_command = "{COMPILE_CMD} -D__GNUC__"
+        f.write(
+            f"""compiler_command = "{COMPILE_CMD} -D__GNUC__"
 assembler_command = "mips-linux-gnu-as -march=r5900 -mabi=eabi -Iinclude"
 compiler_type = "gcc"
 
@@ -84,10 +89,17 @@ compiler_type = "gcc"
 
 [decompme.compilers]
 "tools/build/cc/gcc/gcc" = "ee-gcc2.96"
-""")
+"""
+        )
 
-#MARK: Build
-def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_only=False, dual_objects=False):
+
+# MARK: Build
+def build_stuff(
+    linker_entries: List[LinkerEntry],
+    skip_checksum=False,
+    objects_only=False,
+    dual_objects=False,
+):
     """
     Build the objects and the final ELF file.
     If objects_only is True, only build objects and skip linking/checksum.
@@ -130,7 +142,10 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
                 if obj.suffix in [".s", ".c"]:
                     stem = obj.stem
                 else:
-                    if obj.suffix == ".o" and obj.with_suffix("").suffix in [".s", ".c"]:
+                    if obj.suffix == ".o" and obj.with_suffix("").suffix in [
+                        ".s",
+                        ".c",
+                    ]:
                         stem = obj.with_suffix("").stem
                 target_dir = out_dir if out_dir else obj.parent
                 new_obj = Path(target_dir) / (stem + ".o")
@@ -203,7 +218,7 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
                         "target_path": target_path,
                         "metadata": {
                             "progress_categories": categories,
-                        }
+                        },
                     }
 
                     if has_src:
@@ -219,9 +234,11 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
                         unit["base_path"] = base_path
                     objdiff_units.append(unit)
 
-    ninja = ninja_syntax.Writer(open(str(ROOT / "build.ninja"), "w", encoding="utf-8"), width=9999)
+    ninja = ninja_syntax.Writer(
+        open(str(ROOT / "build.ninja"), "w", encoding="utf-8"), width=9999
+    )
 
-    #MARK: Rules
+    # MARK: Rules
     cross = "mips-linux-gnu-"
 
     ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -Map $mapfile -T $in -o $out --no-warn-rwx-segments"
@@ -256,7 +273,7 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
         command=f"{cross}objcopy $in $out -O binary",
     )
 
-    #MARK: Build
+    # MARK: Build
     # Build all the objects
     for entry in linker_entries:
         seg = entry.segment
@@ -271,38 +288,116 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
             seg, splat.segtypes.common.data.CommonSegData
         ):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "as")
         elif isinstance(seg, splat.segtypes.common.c.CommonSegC):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "cc", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "cc", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "cc",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "cc",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "cc")
         elif isinstance(seg, splat.segtypes.common.databin.CommonSegDatabin):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "as")
         elif isinstance(seg, splat.segtypes.common.rodatabin.CommonSegRodatabin):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "as")
         elif isinstance(seg, splat.segtypes.common.textbin.CommonSegTextbin):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "as")
         elif isinstance(seg, splat.segtypes.common.bin.CommonSegBin):
             if dual_objects:
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/target", collect_objdiff=True, orig_entry=entry)
-                build(entry.object_path, entry.src_paths, "as", out_dir="obj/current", extra_flags="-DSKIP_ASM")
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                    orig_entry=entry,
+                )
+                build(
+                    entry.object_path,
+                    entry.src_paths,
+                    "as",
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
             else:
                 build(entry.object_path, entry.src_paths, "as")
         else:
@@ -334,10 +429,12 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
                     "src/**/*.py",
                     "src/**/*.yml",
                     "src/**/*.txt",
-                    "src/**/*.json"
+                    "src/**/*.json",
                 ],
                 "units": objdiff_units,
-                "progress_categories": [ {"id": id, "name": name} for id, name in CATEGORY_MAP.items() ],
+                "progress_categories": [
+                    {"id": id, "name": name} for id, name in CATEGORY_MAP.items()
+                ],
             }
             with open("objdiff.json", "w", encoding="utf-8") as f:
                 json.dump(objdiff, f, indent=2)
@@ -367,7 +464,8 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
     else:
         print("Skipping checksum step")
 
-#MARK: Short loop fix
+
+# MARK: Short loop fix
 # Pattern to workaround unintended nops around loops
 COMMENT_PART = r"\/\* (.+) ([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2}) \*\/"
 INSTRUCTION_PART = r"(\b(bne|bnel|beq|beql|bnez|bnezl|beqzl|bgez|bgezl|bgtz|bgtzl|blez|blezl|bltz|bltzl|b)\b.*)"
@@ -376,25 +474,26 @@ OPCODE_PATTERN = re.compile(f"{COMMENT_PART}  {INSTRUCTION_PART}")
 PROBLEMATIC_FUNCS = set(
     [
         "PredictAsegEffect__FP4ASEGffP3ALOT3iP6VECTORP7MATRIX3T6T6", # P2/aseg
-        "ProjectBlipgTransform__FP5BLIPGfi",          # P2/blip
-        "ExplodeExplsExplso__FP5EXPLSP6EXPLSO",       # P2/emitter
-        "ApplyDzg__FP3DZGiPiPPP2SOff",                # P2/dzg
-        "UpdateJtActive__FP2JTP3JOYf",                # P2/jt
-        "AddMatrix4Matrix4__FP7MATRIX4N20",           # P2/mat
-        "FInvertMatrix__FiPfT1",                      # P2/mat
-        "RenderMsGlobset__FP2MSP2CMP2RO",             # P2/ms
-        "BounceRipgRips__FP4RIPG",                    # P2/rip
-        "FUN_001aea70",                               # P2/screen
-        "UpdateShadow__FP6SHADOWf",                   # P2/shadow
-        "LoadShadersFromBrx__FP18CBinaryInputStream", # P2/shd
-        "FillShaders__Fi",                            # P2/shd
-        "UpdateStepPhys__FP4STEP",                    # P2/step
-        "DrawTvBands__FP2TVR4GIFS",                   # P2/tv
-        "FIgnoreUbgIntersection__FP3UBGP2SO",         # P2/ub
-        "PwarpFromOid__F3OIDT0",                      # P2/xform
-        "TriggerWarp__FP4WARP"                        # P2/xform
+        "ProjectBlipgTransform__FP5BLIPGfi",                         # P2/blip
+        "ExplodeExplsExplso__FP5EXPLSP6EXPLSO",                      # P2/emitter
+        "ApplyDzg__FP3DZGiPiPPP2SOff",                               # P2/dzg
+        "UpdateJtActive__FP2JTP3JOYf",                               # P2/jt
+        "AddMatrix4Matrix4__FP7MATRIX4N20",                          # P2/mat
+        "FInvertMatrix__FiPfT1",                                     # P2/mat
+        "RenderMsGlobset__FP2MSP2CMP2RO",                            # P2/ms
+        "BounceRipgRips__FP4RIPG",                                   # P2/rip
+        "FUN_001aea70",                                              # P2/screen
+        "UpdateShadow__FP6SHADOWf",                                  # P2/shadow
+        "LoadShadersFromBrx__FP18CBinaryInputStream",                # P2/shd
+        "FillShaders__Fi",                                           # P2/shd
+        "UpdateStepPhys__FP4STEP",                                   # P2/step
+        "DrawTvBands__FP2TVR4GIFS",                                  # P2/tv
+        "FIgnoreUbgIntersection__FP3UBGP2SO",                        # P2/ub
+        "PwarpFromOid__F3OIDT0",                                     # P2/xform
+        "TriggerWarp__FP4WARP"                                       # P2/xform
     ]
 )
+
 
 def replace_instructions_with_opcodes(asm_folder: Path) -> None:
     """
@@ -422,7 +521,8 @@ def replace_instructions_with_opcodes(asm_folder: Path) -> None:
             with p.open("w") as file:
                 file.write(content)
 
-#MARK: Main
+
+# MARK: Main
 def main():
     """
     Main function, parses arguments and runs the configuration.
@@ -473,7 +573,9 @@ def main():
     linker_entries = split.linker_writer.entries
 
     if do_objects:
-        build_stuff(linker_entries, skip_checksum=True, objects_only=True, dual_objects=True)
+        build_stuff(
+            linker_entries, skip_checksum=True, objects_only=True, dual_objects=True
+        )
     else:
         build_stuff(linker_entries, do_skip_checksum)
 
@@ -481,6 +583,7 @@ def main():
 
     if not args.no_short_loop_workaround:
         replace_instructions_with_opcodes(split.config["options"]["asm_path"])
+
 
 if __name__ == "__main__":
     main()

--- a/configure.py
+++ b/configure.py
@@ -352,28 +352,26 @@ COMMENT_PART = r"\/\* (.+) ([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2}) 
 INSTRUCTION_PART = r"(\b(bne|bnel|beq|beql|bnez|bnezl|beqzl|bgez|bgezl|bgtz|bgtzl|blez|blezl|bltz|bltzl|b)\b.*)"
 OPCODE_PATTERN = re.compile(f"{COMMENT_PART}  {INSTRUCTION_PART}")
 
-PROBLEMATIC_FUNCS = set(
-    [
-        "PredictAsegEffect__FP4ASEGffP3ALOT3iP6VECTORP7MATRIX3T6T6", # P2/aseg
-        "ProjectBlipgTransform__FP5BLIPGfi",                         # P2/blip
-        "ExplodeExplsExplso__FP5EXPLSP6EXPLSO",                      # P2/emitter
-        "ApplyDzg__FP3DZGiPiPPP2SOff",                               # P2/dzg
-        "UpdateJtActive__FP2JTP3JOYf",                               # P2/jt
-        "AddMatrix4Matrix4__FP7MATRIX4N20",                          # P2/mat
-        "FInvertMatrix__FiPfT1",                                     # P2/mat
-        "RenderMsGlobset__FP2MSP2CMP2RO",                            # P2/ms
-        "BounceRipgRips__FP4RIPG",                                   # P2/rip
-        "FUN_001aea70",                                              # P2/screen
-        "UpdateShadow__FP6SHADOWf",                                  # P2/shadow
-        "LoadShadersFromBrx__FP18CBinaryInputStream",                # P2/shd
-        "FillShaders__Fi",                                           # P2/shd
-        "UpdateStepPhys__FP4STEP",                                   # P2/step
-        "DrawTvBands__FP2TVR4GIFS",                                  # P2/tv
-        "FIgnoreUbgIntersection__FP3UBGP2SO",                        # P2/ub
-        "PwarpFromOid__F3OIDT0",                                     # P2/xform
-        "TriggerWarp__FP4WARP"                                       # P2/xform
-    ]
-)
+PROBLEMATIC_FUNCS = {
+    "PredictAsegEffect__FP4ASEGffP3ALOT3iP6VECTORP7MATRIX3T6T6", # P2/aseg
+    "ProjectBlipgTransform__FP5BLIPGfi",                         # P2/blip
+    "ExplodeExplsExplso__FP5EXPLSP6EXPLSO",                      # P2/emitter
+    "ApplyDzg__FP3DZGiPiPPP2SOff",                               # P2/dzg
+    "UpdateJtActive__FP2JTP3JOYf",                               # P2/jt
+    "AddMatrix4Matrix4__FP7MATRIX4N20",                          # P2/mat
+    "FInvertMatrix__FiPfT1",                                     # P2/mat
+    "RenderMsGlobset__FP2MSP2CMP2RO",                            # P2/ms
+    "BounceRipgRips__FP4RIPG",                                   # P2/rip
+    "FUN_001aea70",                                              # P2/screen
+    "UpdateShadow__FP6SHADOWf",                                  # P2/shadow
+    "LoadShadersFromBrx__FP18CBinaryInputStream",                # P2/shd
+    "FillShaders__Fi",                                           # P2/shd
+    "UpdateStepPhys__FP4STEP",                                   # P2/step
+    "DrawTvBands__FP2TVR4GIFS",                                  # P2/tv
+    "FIgnoreUbgIntersection__FP3UBGP2SO",                        # P2/ub
+    "PwarpFromOid__F3OIDT0",                                     # P2/xform
+    "TriggerWarp__FP4WARP"                                       # P2/xform
+}
 
 
 def replace_instructions_with_opcodes(asm_folder: Path) -> None:

--- a/configure.py
+++ b/configure.py
@@ -34,7 +34,7 @@ COMMON_INCLUDES = "-Iinclude -isystem include/sdk/ee -isystem include/gcc"
 CC_DIR = f"{TOOLS_DIR}/cc/bin"
 COMMON_COMPILE_FLAGS = f"-x c++ -B{TOOLS_DIR}/cc/lib/gcc-lib/ee/2.95.2/ -O2 -G0 -ffast-math"
 
-WINE = "wine"
+WINE = "WINEDEBUG=-all wine"
 
 GAME_GCC_CMD = f"{CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
 COMPILE_CMD = f"{GAME_GCC_CMD}"
@@ -224,7 +224,7 @@ def build_stuff(linker_entries: List[LinkerEntry], skip_checksum=False, objects_
     #MARK: Rules
     cross = "mips-linux-gnu-"
 
-    ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -Map $mapfile -T $in -o $out"
+    ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -Map $mapfile -T $in -o $out --no-warn-rwx-segments"
 
     ninja.rule(
         "as",

--- a/configure.py
+++ b/configure.py
@@ -11,7 +11,7 @@ import sys
 import json
 import re
 from pathlib import Path
-from typing import Dict, List, Set, Union
+from typing import List, Set
 
 import ninja_syntax
 import splat
@@ -39,10 +39,11 @@ COMMON_COMPILE_FLAGS = (
 
 WINE = "WINEDEBUG=-all wine"
 
-GAME_GCC_CMD = f"{CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
-COMPILE_CMD = f"{GAME_GCC_CMD}"
-if sys.platform == "linux" or sys.platform == "linux2":
-    COMPILE_CMD = f"{WINE} {GAME_GCC_CMD}"
+COMPILE_CMD = f"{CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
+if sys.platform == "linux":
+    COMPILE_CMD = (
+        f"{WINE} {CC_DIR}/ee-gcc.exe -c {COMMON_INCLUDES} {COMMON_COMPILE_FLAGS} $in"
+    )
 
 CATEGORY_MAP = {
     "P2": "Engine",
@@ -51,6 +52,19 @@ CATEGORY_MAP = {
     "sce": "Libs",
     "data": "Data",
 }
+
+# Segment types that should be assembled
+ASSEMBLABLE_TYPES = (
+    splat.segtypes.common.asm.CommonSegAsm,
+    splat.segtypes.common.data.CommonSegData,
+    splat.segtypes.common.databin.CommonSegDatabin,
+    splat.segtypes.common.rodatabin.CommonSegRodatabin,
+    splat.segtypes.common.textbin.CommonSegTextbin,
+    splat.segtypes.common.bin.CommonSegBin,
+)
+
+# Segment types that should be compiled
+COMPILABLE_TYPES = (splat.segtypes.common.c.CommonSegC,)
 
 
 def clean():
@@ -94,375 +108,242 @@ compiler_type = "gcc"
 
 
 # MARK: Build
-def build_stuff(
+def generate_ninja_build(
     linker_entries: List[LinkerEntry],
     skip_checksum=False,
     objects_only=False,
     dual_objects=False,
 ):
     """
-    Build the objects and the final ELF file.
+    Generate ninja build rules for objects and the final ELF file.
     If objects_only is True, only build objects and skip linking/checksum.
     If dual_objects is True, build objects twice: once normally, once with -DSKIP_ASM.
     """
     built_objects: Set[Path] = set()
     objdiff_units = []  # For objdiff.json
 
-    def build(
-        object_paths: Union[Path, List[Path]],
+    def compute_object_path(obj_path: Path, out_dir: str = None) -> Path:
+        """Compute the final object path, stripping .s or .c extensions if needed."""
+        if not out_dir:
+            return obj_path
+
+        # Strip .s/.c extensions or handle .c.o/.s.o cases
+        if obj_path.suffix == ".o" and obj_path.with_suffix("").suffix in [".s", ".c"]:
+            stem = obj_path.with_suffix("").stem
+        else:
+            stem = obj_path.stem
+
+        return Path(out_dir) / (stem + ".o")
+
+    def collect_objdiff_unit(object_path: Path, src_path: Path) -> None:
+        """Collect objdiff metadata for a compilation unit."""
+        if not src_path or "target" not in str(object_path):
+            return
+
+        # Compute relative path for name
+        try:
+            if src_path.parts[0] in ["asm", "src"]:
+                rel = Path(*src_path.parts[1:])
+            else:
+                rel = src_path
+            name = str(rel.with_suffix(""))
+        except (IndexError, ValueError):
+            name = str(src_path.with_suffix(""))
+
+        target_path = str(object_path)
+
+        # Check if source file exists in src/
+        src_base = rel.with_suffix("")
+        has_src = any(Path("src").rglob(src_base.name + ext) for ext in [".c", ".cpp"])
+
+        # Determine categories
+        categories = [name.split("/")[0]]
+        if "P2/splice/" in name:
+            categories.append("splice")
+        elif "P2/ps2t" in name:
+            categories.append("ps2t")
+
+        unit = {
+            "name": name,
+            "target_path": target_path,
+            "metadata": {"progress_categories": categories},
+        }
+
+        if has_src:
+            # Replace 'target' segment with 'current' in path
+            op = Path(object_path)
+            parts = list(op.parts)
+            for idx, part in enumerate(parts):
+                if part == "target":
+                    parts[idx] = "current"
+                    break
+            unit["base_path"] = str(Path(*parts))
+
+        objdiff_units.append(unit)
+
+    def build_object(
+        object_path: Path,
         src_paths: List[Path],
-        task: str,
-        variables: Dict[str, str] = None,
-        implicit_outputs: List[str] = None,
+        rule: str,
         out_dir: str = None,
         extra_flags: str = "",
         collect_objdiff: bool = False,
-        orig_entry=None,
     ):
-        """
-        Helper function to build objects.
-        """
-        # Handle none parameters
-        if variables is None:
-            variables = {}
+        """Build a single object file."""
+        final_path = compute_object_path(object_path, out_dir)
 
-        if implicit_outputs is None:
-            implicit_outputs = []
+        if final_path.suffix == ".o":
+            built_objects.add(final_path)
 
-        # Convert object_paths to list if it is not already
-        if not isinstance(object_paths, list):
-            object_paths = [object_paths]
+        build_vars = {"cflags": extra_flags} if extra_flags else {}
 
-        # Only rewrite output path to .o if out_dir is set (i.e. --objects mode)
-        if out_dir:
-            new_object_paths = []
-            for obj in object_paths:
-                obj = Path(obj)
-                stem = obj.stem
-                if obj.suffix in [".s", ".c"]:
-                    stem = obj.stem
-                else:
-                    if obj.suffix == ".o" and obj.with_suffix("").suffix in [
-                        ".s",
-                        ".c",
-                    ]:
-                        stem = obj.with_suffix("").stem
-                target_dir = out_dir if out_dir else obj.parent
-                new_obj = Path(target_dir) / (stem + ".o")
-                new_object_paths.append(new_obj)
-            object_paths = new_object_paths
-
-        # Otherwise, use the original object_paths (with .s.o, .c.o, etc.)
-
-        # Add object paths to built_objects
-        for idx, object_path in enumerate(object_paths):
-            if object_path.suffix == ".o":
-                built_objects.add(object_path)
-
-            # Add extra_flags to variables if present
-            build_vars = variables.copy()
-            if extra_flags:
-                build_vars["cflags"] = extra_flags
-            ninja.build(
-                outputs=[str(object_path)],
-                rule=task,
-                inputs=[str(s) for s in src_paths],
-                variables=build_vars,
-                implicit_outputs=implicit_outputs,
-            )
-
-            # Collect for objdiff.json if requested
-            if collect_objdiff and orig_entry is not None:
-                src = src_paths[0] if src_paths else None
-                if src:
-                    src = Path(src)
-                    # Always use the final "matched" name, i.e. as if it will be in src/ with no asm/ prefix
-                    try:
-                        # If the file is in asm/, replace asm/ with nothing (just drop asm/)
-                        if src.parts[0] == "asm":
-                            rel = Path(*src.parts[1:])
-                        elif src.parts[0] == "src":
-                            rel = Path(*src.parts[1:])
-                        else:
-                            rel = src
-                        # Remove extension for the name
-                        name = str(rel.with_suffix(""))
-                    except Exception:
-                        name = str(src.with_suffix(""))
-                else:
-                    name = object_path.stem
-                    # Ensure `rel` is defined so later code can compute src-based paths
-                    try:
-                        rel = Path(object_path)
-                    except Exception:
-                        rel = Path(str(object_path))
-
-                if "target" in str(object_path):
-                    target_path = str(object_path)
-
-                    # Determine if a .c or .cpp file exists in src/ for this unit (recursively)
-                    src_base = rel.with_suffix("")
-                    src_c_files = list(Path("src").rglob(src_base.name + ".c"))
-                    src_cpp_files = list(Path("src").rglob(src_base.name + ".cpp"))
-                    has_src = bool(src_c_files or src_cpp_files)
-
-                    # Determine the category based on the name
-                    categories = [name.split("/")[0]]
-                    if "P2/splice/" in name:
-                        categories.append("splice")
-                    elif "P2/ps2t" in name:
-                        categories.append("ps2t")
-
-                    unit = {
-                        "name": name,
-                        "target_path": target_path,
-                        "metadata": {
-                            "progress_categories": categories,
-                        },
-                    }
-
-                    if has_src:
-                        # Replace only the path segment named 'target' with 'current',
-                        # preserving any filenames that may contain the substring "target".
-                        op = Path(object_path)
-                        parts = list(op.parts)
-                        for idx, part in enumerate(parts):
-                            if part == "target":
-                                parts[idx] = "current"
-                                break
-                        base_path = str(Path(*parts))
-                        unit["base_path"] = base_path
-                    objdiff_units.append(unit)
-
-    ninja = ninja_syntax.Writer(
-        open(str(ROOT / "build.ninja"), "w", encoding="utf-8"), width=9999
-    )
-
-    # MARK: Rules
-    cross = "mips-linux-gnu-"
-
-    ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -Map $mapfile -T $in -o $out --no-warn-rwx-segments"
-
-    ninja.rule(
-        "as",
-        description="as $in",
-        command=f"cpp {COMMON_INCLUDES} $in -o  - | {cross}as -no-pad-sections -EL -march=5900 -mabi=eabi -Iinclude -o $out",
-    )
-
-    ninja.rule(
-        "cc",
-        description="cc $in",
-        command=f"{COMPILE_CMD} $cflags -o $out && {cross}strip $out -N dummy-symbol-name",
-    )
-
-    ninja.rule(
-        "ld",
-        description="link $out",
-        command=f"{cross}ld {ld_args}",
-    )
-
-    ninja.rule(
-        "sha1sum",
-        description="sha1sum $in",
-        command="sha1sum -c $in && touch $out",
-    )
-
-    ninja.rule(
-        "elf",
-        description="elf $out",
-        command=f"{cross}objcopy $in $out -O binary",
-    )
-
-    # MARK: Build
-    # Build all the objects
-    for entry in linker_entries:
-        seg = entry.segment
-
-        if seg.type[0] == ".":
-            continue
-
-        if entry.object_path is None:
-            continue
-
-        if isinstance(seg, splat.segtypes.common.asm.CommonSegAsm) or isinstance(
-            seg, splat.segtypes.common.data.CommonSegData
-        ):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "as")
-        elif isinstance(seg, splat.segtypes.common.c.CommonSegC):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "cc",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "cc",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "cc")
-        elif isinstance(seg, splat.segtypes.common.databin.CommonSegDatabin):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "as")
-        elif isinstance(seg, splat.segtypes.common.rodatabin.CommonSegRodatabin):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "as")
-        elif isinstance(seg, splat.segtypes.common.textbin.CommonSegTextbin):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "as")
-        elif isinstance(seg, splat.segtypes.common.bin.CommonSegBin):
-            if dual_objects:
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/target",
-                    collect_objdiff=True,
-                    orig_entry=entry,
-                )
-                build(
-                    entry.object_path,
-                    entry.src_paths,
-                    "as",
-                    out_dir="obj/current",
-                    extra_flags="-DSKIP_ASM",
-                )
-            else:
-                build(entry.object_path, entry.src_paths, "as")
-        else:
-            print(f"ERROR: Unsupported build segment type {seg.type}")
-            sys.exit(1)
-
-    if objects_only:
-        # Write objdiff.json if dual_objects (i.e. --objects)
-        if dual_objects:
-            objdiff = {
-                "$schema": "https://raw.githubusercontent.com/encounter/objdiff/main/config.schema.json",
-                "custom_make": "ninja",
-                "custom_args": [],
-                "build_target": False,
-                "build_base": True,
-                "watch_patterns": [
-                    "src/**/*.c",
-                    "src/**/*.cp",
-                    "src/**/*.cpp",
-                    "src/**/*.cxx",
-                    "src/**/*.h",
-                    "src/**/*.hp",
-                    "src/**/*.hpp",
-                    "src/**/*.hxx",
-                    "src/**/*.s",
-                    "src/**/*.S",
-                    "src/**/*.asm",
-                    "src/**/*.inc",
-                    "src/**/*.py",
-                    "src/**/*.yml",
-                    "src/**/*.txt",
-                    "src/**/*.json",
-                ],
-                "units": objdiff_units,
-                "progress_categories": [
-                    {"id": id, "name": name} for id, name in CATEGORY_MAP.items()
-                ],
-            }
-            with open("objdiff.json", "w", encoding="utf-8") as f:
-                json.dump(objdiff, f, indent=2)
-        return
-
-    ninja.build(
-        PRE_ELF_PATH,
-        "ld",
-        LD_PATH,
-        implicit=[str(obj) for obj in built_objects],
-        variables={"mapfile": MAP_PATH},
-    )
-
-    ninja.build(
-        ELF_PATH,
-        "elf",
-        PRE_ELF_PATH,
-    )
-
-    if not skip_checksum:
         ninja.build(
-            ELF_PATH + ".ok",
-            "sha1sum",
-            "config/checksum.sha1",
-            implicit=[ELF_PATH],
+            outputs=[str(final_path)],
+            rule=rule,
+            inputs=[str(s) for s in src_paths],
+            variables=build_vars,
         )
-    else:
-        print("Skipping checksum step")
+
+        if collect_objdiff and src_paths:
+            collect_objdiff_unit(final_path, src_paths[0])
+
+    with open(str(ROOT / "build.ninja"), "w", encoding="utf-8") as f:
+        ninja = ninja_syntax.Writer(f, width=9999)
+
+        # MARK: Rules
+        cross = "mips-linux-gnu-"
+
+        ld_args = "-EL -T config/undefined_syms_auto.txt -T config/undefined_funcs_auto.txt -Map $mapfile -T $in -o $out --no-warn-rwx-segments"
+
+        ninja.rule(
+            "as",
+            description="as $in",
+            command=f"cpp {COMMON_INCLUDES} $in -o  - | {cross}as -no-pad-sections -EL -march=5900 -mabi=eabi -Iinclude -o $out",
+        )
+
+        ninja.rule(
+            "cc",
+            description="cc $in",
+            command=f"{COMPILE_CMD} $cflags -o $out && {cross}strip $out -N dummy-symbol-name",
+        )
+
+        ninja.rule(
+            "ld",
+            description="link $out",
+            command=f"{cross}ld {ld_args}",
+        )
+
+        ninja.rule(
+            "sha1sum",
+            description="sha1sum $in",
+            command="sha1sum -c $in && touch $out",
+        )
+
+        ninja.rule(
+            "elf",
+            description="elf $out",
+            command=f"{cross}objcopy $in $out -O binary",
+        )
+
+        # MARK: Object compilation
+        # Build all the objects
+        for entry in linker_entries:
+            seg = entry.segment
+
+            if seg.type[0] == ".":
+                continue
+
+            if entry.object_path is None:
+                continue
+
+            # Determine rule based on segment type
+            rule = None
+            if isinstance(seg, COMPILABLE_TYPES):
+                rule = "cc"
+            elif isinstance(seg, ASSEMBLABLE_TYPES):
+                rule = "as"
+            else:
+                print(f"ERROR: Unsupported build segment type {seg.type}")
+                sys.exit(1)
+
+            # Build objects (single or dual mode)
+            if dual_objects:
+                build_object(
+                    entry.object_path,
+                    entry.src_paths,
+                    rule,
+                    out_dir="obj/target",
+                    collect_objdiff=True,
+                )
+                build_object(
+                    entry.object_path,
+                    entry.src_paths,
+                    rule,
+                    out_dir="obj/current",
+                    extra_flags="-DSKIP_ASM",
+                )
+            else:
+                build_object(entry.object_path, entry.src_paths, rule)
+
+        if objects_only:
+            # Write objdiff.json if dual_objects (i.e. --objects)
+            if dual_objects:
+                objdiff = {
+                    "$schema": "https://raw.githubusercontent.com/encounter/objdiff/main/config.schema.json",
+                    "custom_make": "ninja",
+                    "custom_args": [],
+                    "build_target": False,
+                    "build_base": True,
+                    "watch_patterns": [
+                        "src/**/*.c",
+                        "src/**/*.cp",
+                        "src/**/*.cpp",
+                        "src/**/*.cxx",
+                        "src/**/*.h",
+                        "src/**/*.hp",
+                        "src/**/*.hpp",
+                        "src/**/*.hxx",
+                        "src/**/*.s",
+                        "src/**/*.S",
+                        "src/**/*.asm",
+                        "src/**/*.inc",
+                        "src/**/*.py",
+                        "src/**/*.yml",
+                        "src/**/*.txt",
+                        "src/**/*.json",
+                    ],
+                    "units": objdiff_units,
+                    "progress_categories": [
+                        {"id": id, "name": name} for id, name in CATEGORY_MAP.items()
+                    ],
+                }
+                with open("objdiff.json", "w", encoding="utf-8") as objdiff_file:
+                    json.dump(objdiff, objdiff_file, indent=2)
+            return
+
+        ninja.build(
+            PRE_ELF_PATH,
+            "ld",
+            LD_PATH,
+            implicit=[str(obj) for obj in built_objects],
+            variables={"mapfile": MAP_PATH},
+        )
+
+        ninja.build(
+            ELF_PATH,
+            "elf",
+            PRE_ELF_PATH,
+        )
+
+        if not skip_checksum:
+            ninja.build(
+                ELF_PATH + ".ok",
+                "sha1sum",
+                "config/checksum.sha1",
+                implicit=[ELF_PATH],
+            )
+        else:
+            print("Skipping checksum step")
 
 
 # MARK: Short loop fix
@@ -559,11 +440,7 @@ def main():
     )
     args = parser.parse_args()
 
-    do_clean = (args.clean or args.clean_only) or False
-    do_skip_checksum = args.skip_checksum or False
-    do_objects = args.objects or False
-
-    if do_clean:
+    if args.clean or args.clean_only:
         clean()
         if args.clean_only:
             return
@@ -572,12 +449,12 @@ def main():
 
     linker_entries = split.linker_writer.entries
 
-    if do_objects:
-        build_stuff(
+    if args.objects:
+        generate_ninja_build(
             linker_entries, skip_checksum=True, objects_only=True, dual_objects=True
         )
     else:
-        build_stuff(linker_entries, do_skip_checksum)
+        generate_ninja_build(linker_entries, args.skip_checksum)
 
     write_permuter_settings()
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,15 +43,25 @@ Once you have a function selected, you can start matching it using either **Objd
 
 [Objdiff](https://github.com/encounter/objdiff), is a tool for showing the diff between a symbol in two object files. It is faster and more convenient then Decomp.me since it is included in the project, and doesn't require uploading anything to a website.
 
-1. Reconfigure the project using `python3 configure.py --objects`. This will generate the object files and the `objdiff.json` config file, but it won't build the final elf or run the checksum.
-2. From the project root, run `./tools/objdiff/objdiff-cli diff --project . -u P2/objname FunctionName`.
-    * Replace `objname` with the name of the object file the function is in.
+1. Place your new function under the `INCLUDE_ASM` macro of the function you want to match wrapped in `#ifdef SKIP_ASM` like so:
+
+   ```cpp
+   INCLUDE_ASM("asm/nonmatchings/P2/difficulty", OnDifficultyGameLoad__FP10DIFFICULTY);
+   #ifdef SKIP_ASM
+   void OnDifficultyGameLoad(DIFFICULTY *pdifficulty)
+   {
+      ...
+   }
+   #endif
+   ```
+2. From the project root, run `./scripts/diff.sh FunctionName [ObjectName]`.
     * Replace `FunctionName` with the **mangled name** of the function you want to match.
+    * Optionally, provide `ObjectName` using the name of the object file (without extension) if you know which file contains the function.
 3. Edit the source code until the function matches. The CURRENT assembly will update every time you save the file.
 
-**Example:** To match `OnDifficultyGameLoad` defined in `difficulty.c`, run this command:
+**Example:** To match `OnDifficultyGameLoad` defined in `P2/difficulty.c`, run this command:
 ```bash
-./tools/objdiff/objdiff-cli diff --project . -u P2/difficulty OnDifficultyGameLoad__FP10DIFFICULTY
+./scripts/diff.sh OnDifficultyGameLoad__FP10DIFFICULTY P2/difficulty
 ```
 
 ### Decomp.me
@@ -81,7 +91,7 @@ Once the function matches 100%, follow these steps to integrate it into the proj
 The project should build and match. Here are some common troubleshooting tips:
 * `undefined reference error` usually means the entry in the symbol_addrs.txt is wrong. Make sure the function name is mangled in symbol_addrs.txt and unmangled in the source code, and the mangled version matches the signature of the function. Also ensure that the address is correct in symbol_addrs.txt.
 * `checksum failed` means the compiled elf with your added code doesn't match the original. If it matches on decomp.me but not in the project, it might be an issue with the compiler, so open an issue on GitHub or let someone know on Discord.
-* `ninja: no work to do` in objdiff likely means the name of the function is wrong in your objdiff command and/or in symbol_addrs.txt. Make sure you are using the correct mangled name of the function in both places.
+* `ninja: no work to do` in diff.sh likely means the name of the function is wrong in your command and/or in symbol_addrs.txt. Make sure you are using the correct mangled name of the function in both places.
 
 <!--### CodeMatcher
 

--- a/docs/DISTROBOX.md
+++ b/docs/DISTROBOX.md
@@ -1,0 +1,115 @@
+# Using Distrobox for Non-Debian Distributions
+
+If you're using a non-Debian Linux distribution (such as Fedora, Arch, openSUSE, etc.), you can use [Distrobox](https://distrobox.it/) to create a Debian container and follow the standard setup instructions.
+
+## What is Distrobox?
+
+Distrobox is a tool that lets you create and manage containerized Linux environments that integrate seamlessly with your host system. Unlike traditional containers, Distrobox containers share your home directory to allow collaboration with the host system. You can edit the code in your favorite editor and build the project in the container using those same files.
+
+This makes it perfect for development work where you need a specific distribution's tooling.
+
+## Installing Distrobox
+
+### Fedora:
+```bash
+sudo dnf install distrobox
+```
+
+### Arch Linux:
+```bash
+sudo pacman -S distrobox
+```
+
+### openSUSE:
+```bash
+sudo zypper install distrobox
+```
+
+## Setting up the Debian Container
+
+### 1. Create the container
+
+Create a Debian container. It can be named anything but for this example we use `sly1-dev`:
+
+```bash
+distrobox create --name sly1-dev --init --image debian:latest --additional-packages "git"
+```
+
+This downloads the latest Debian image and creates a new container.
+
+### 2. Enter the container
+
+```bash
+distrobox enter sly1-dev
+```
+
+The first time you enter, Distrobox will set up the container environment.
+
+### 3. Verify you're in the container
+
+Your terminal prompt should change to indicate you're in the container (typically showing `user@sly1-dev`). You can further verify with:
+
+```bash
+cat /etc/os-release
+```
+
+Which should show Debian information.
+
+## Following the Setup Instructions
+
+Once inside the container, you can follow the [README instructions](../README.md#-quickstart).
+
+Again, your home directory is shared between the host and container, so you can clone the repository using either.
+
+## Exiting the Container
+
+When you're done working, simply exit the container:
+
+```bash
+exit
+```
+
+Or press `Ctrl+D`.
+
+## Working with the Container
+
+### Re-entering the container
+
+Whenever you want to build the project, just enter the container again:
+
+```bash
+distrobox enter sly1-dev
+cd ~/path/to/sly1
+```
+
+### Running commands from outside
+
+You can also run commands inside the container without entering it:
+
+```bash
+distrobox enter sly1-dev -- ./scripts/build.sh
+```
+
+### Stopping the container
+
+Containers are automatically stopped when not in use. To manually stop:
+
+```bash
+distrobox stop sly1-dev
+```
+
+### Removing the container
+
+If you need to start fresh:
+
+```bash
+distrobox rm sly1-dev
+```
+
+This deletes the container and any packages installed within it. You will need to complete the setup instructions again if you create a new container.
+
+## Troubleshooting
+
+### Run.sh is not finding PCSX2
+
+If PCSX2 is installed on the host system via package manager the container will not be able to find it. Either exit the container or install PCSX2 in a way the container can access, such as the container package manager, Flatpak or AppImage.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
+set -e
 
-# Get directory of this script
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-# CD into project dir
-cd $DIR/..
+PROJECT_DIR="$(dirname "$0")/.."
 
 # Ensure disc/SCUS_971.98 exists
-if [ ! -f disc/SCUS_971.98 ]; then
-  echo "Error: SCUS_971.98 not found. Copy it from your own game disc to the 'disc' directory of this project."
-  exit
+if [ ! -f "$PROJECT_DIR/disc/SCUS_971.98" ]; then
+    echo "Error: SCUS_971.98 not found. Copy it from your own game disc to the 'disc' directory of this project." >&2
+    exit 1
 fi
 
-# Configure and build
-python3 configure.py --clean
+pushd $PROJECT_DIR > /dev/null
+trap "popd > /dev/null" EXIT
+
+source "env/bin/activate"
+python3 "configure.py" --clean
 ninja

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,8 @@ fi
 pushd $PROJECT_DIR > /dev/null
 trap "popd > /dev/null" EXIT
 
-source "env/bin/activate"
+if [ -z "$VIRTUAL_ENV" ]; then
+    source "env/bin/activate"
+fi
 python3 "configure.py" --clean
 ninja

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -6,7 +6,9 @@ PROJECT_DIR="$(dirname "$0")/.."
 pushd $PROJECT_DIR > /dev/null
 trap "popd > /dev/null" EXIT
 
-source "env/bin/activate"
+if [ -z "$VIRTUAL_ENV" ]; then
+    source "env/bin/activate"
+fi
 python3 "configure.py" --clean && ninja
 python3 "configure.py" --clean --objects && ninja
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-
 set -e
 
-script_dir=$(dirname $0)
-pushd $script_dir/.. > /dev/null
+PROJECT_DIR="$(dirname "$0")/.."
 
-python3 configure.py --clean && ninja
-python3 configure.py --clean --objects && ninja
+pushd $PROJECT_DIR > /dev/null
+trap "popd > /dev/null" EXIT
+
+source "env/bin/activate"
+python3 "configure.py" --clean && ninja
+python3 "configure.py" --clean --objects && ninja
 
 # Output the progress report to a file if --report is not passed, otherwise discard it.
 if [[ "$1" == "--report" ]]; then

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -7,7 +7,9 @@ if [ -z "$1" ]; then
 fi
 
 cd "$(dirname "$0")/.."
-source env/bin/activate
+if [ -z "$VIRTUAL_ENV" ]; then
+	source "env/bin/activate"
+fi
 python3 configure.py --objects
 ninja
 

--- a/scripts/diff.sh
+++ b/scripts/diff.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+	echo "Usage: $0 FunctionName [ObjectName]" >&2
+	exit 1
+fi
+
+cd "$(dirname "$0")/.."
+source env/bin/activate
+python3 configure.py --objects
+ninja
+
+if [ -n "$2" ]; then
+	./tools/objdiff/objdiff-cli diff --project . -u "$2" "$1"
+else
+	./tools/objdiff/objdiff-cli diff --project . "$1"
+fi

--- a/scripts/extract_elf.sh
+++ b/scripts/extract_elf.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+ISO_FILE="$1"
+
+# Check for ISO
+[ -z "$ISO_FILE" ] && {
+    echo "Error: No ISO path provided." >&2;
+    echo "Usage: $0 /path/to/game.iso" >&2;
+    exit 1;
+}
+
+[ ! -f "$ISO_FILE" ] && {
+    echo "Error: ISO file not found: $ISO_FILE" >&2;
+    exit 1;
+}
+
+PROJECT_DIR="$(dirname "$0")/.."
+ELF_FILE="$PROJECT_DIR/disc/SCUS_971.98"
+CHECKSUM="57dc305db57932ad3f1122966cdb695d2e62a47a"
+
+# Extract SCUS_971.98
+echo "Extracting from $ISO_FILE..."
+if command -v bsdtar &>/dev/null; then
+    bsdtar --no-same-permissions --no-same-owner -xf "$ISO_FILE" -C "$PROJECT_DIR/disc" SCUS_971.98
+    elif command -v 7z &>/dev/null; then
+    7z e "$ISO_FILE" -o"$PROJECT_DIR/disc" SCUS_971.98 -y
+    elif command -v isoinfo &>/dev/null; then
+    isoinfo -i "$ISO_FILE" -x /SCUS_971.98 > "$ELF_FILE"
+else
+    echo "Error: No extraction tool found. Install bsdtar, 7z, or isoinfo." >&2
+    exit 1
+fi
+
+[ ! -f "$ELF_FILE" ] && { echo "Extraction failed." >&2; exit 1; }
+chmod 644 "$ELF_FILE"
+
+# Verify checksum
+echo "Verifying SCUS_971.98..."
+ACTUAL=$(sha1sum "$ELF_FILE" | awk '{print $1}')
+if [ "$ACTUAL" != "$CHECKSUM" ]; then
+    echo "Error: Checksum mismatch! Expected: $CHECKSUM, Got: $ACTUAL" >&2
+    echo "Please ensure you have the correct version of the game (NTSC-U)." >&2
+    exit 1
+fi
+
+echo "SCUS_971.98 is ready!"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -53,5 +53,4 @@ if [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
     echo "Now, copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
 fi
 echo ""
-echo "To enter the python virtual environment, run 'source env/bin/activate' in the project root directory."
-echo "Then, to build the project, run '$(dirname "$0")/build.sh'"
+echo "To build the project, run '$(dirname "$0")/build.sh'"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -22,20 +22,21 @@ sudo apt-get update
 # Setup wine
 sudo dpkg --add-architecture i386
 sudo apt-get update
-sudo apt-get install wine32
+sudo apt-get install -y wine32
 
 # Install MIPS assembler
-sudo apt-get install binutils-mips-linux-gnu
+sudo apt-get install -y binutils-mips-linux-gnu
+
+# Install Ninja build system
+sudo apt-get install -y ninja-build
 
 # Setup compiler
-sudo ./setup_progd_linux.sh
+./setup_prodg_linux.sh
 
 # Check if disc/SCUS_971.98 exists
 echo "Setup complete!"
 if [ ! -f ../disc/SCUS_971.98 ]; then
   echo "Now, copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
-  echo "Then build the project by running the 'build.sh' script."
-  exit
 fi
 echo "To build the project, run the 'build.sh' script."
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -3,10 +3,12 @@ set -e
 
 ### Install Dependencies ###
 
-PACKAGES="binutils-mips-linux-gnu ninja-build python3 python3-pip python3-venv wine32"
+PACKAGES="binutils-mips-linux-gnu ninja-build python3 python3-pip python3-venv"
 ISO_ARG="$1"
 PROJECT_DIR="$(dirname "$0")/.."
 DISC_DIR="$PROJECT_DIR/disc"
+TOOLS_DIR="$PROJECT_DIR/tools"
+WIBO_URL="https://github.com/decompals/wibo/releases/download/1.0.0/wibo-i686"
 
 # If no ISO specified, look for one in the disc directory
 if [ -z "$ISO_ARG" ] && [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
@@ -28,6 +30,17 @@ if [ -n "$ISO_ARG" ]; then
 	fi
 	ISO_ARG="$(realpath "$ISO_ARG")"
     PACKAGES="$PACKAGES libarchive-tools"
+fi
+
+# Download Wibo
+WIBO_PATH="$TOOLS_DIR/wibo-i686"
+echo "Downloading Wibo..."
+mkdir -p "$TOOLS_DIR"
+if wget -q -O "$WIBO_PATH" "$WIBO_URL"; then
+	chmod +x "$WIBO_PATH"
+else
+	echo "Wibo download failed, adding wine32 to dependencies instead..."
+	PACKAGES="$PACKAGES wine32"
 fi
 
 # Install missing dependencies

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -4,6 +4,31 @@ set -e
 ### Install Dependencies ###
 
 PACKAGES="binutils-mips-linux-gnu ninja-build python3 python3-pip python3-venv wine32"
+ISO_ARG="$1"
+PROJECT_DIR="$(dirname "$0")/.."
+DISC_DIR="$PROJECT_DIR/disc"
+
+# If no ISO specified, look for one in the disc directory
+if [ -z "$ISO_ARG" ] && [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
+	echo "No ISO file specified, looking in disc directory..."
+	ISO_FILES=("$DISC_DIR"/*.iso)
+	if [ -f "${ISO_FILES[0]}" ]; then
+		ISO_ARG="${ISO_FILES[0]}"
+		echo "Found ISO: $(basename "$ISO_ARG")"
+	else
+	    echo "No ISO found in disc directory. Skipping executable extraction."
+	fi
+fi
+
+# If ISO is specified, validate it
+if [ -n "$ISO_ARG" ]; then
+	if [ ! -f "$ISO_ARG" ]; then
+		echo "Error: ISO file not found: $ISO_ARG" >&2
+		exit 1
+	fi
+	ISO_ARG="$(realpath "$ISO_ARG")"
+    PACKAGES="$PACKAGES libarchive-tools"
+fi
 
 # Install missing dependencies
 if ! sudo -n true 2>/dev/null; then
@@ -11,7 +36,7 @@ if ! sudo -n true 2>/dev/null; then
 fi
 
 if ! sudo -v; then
-    echo "Error: Unable to obtain root privileges"
+    echo "Error: Unable to obtain root privileges" >&2
     exit 1
 fi
 
@@ -24,8 +49,6 @@ sudo apt-get update -qq > /dev/null
 echo "Dependencies: $PACKAGES"
 echo "Installing missing dependencies..."
 sudo apt-get install -y -qq $PACKAGES > /dev/null
-
-PROJECT_DIR="$(dirname "$0")/.."
 
 pushd $PROJECT_DIR > /dev/null
 trap "popd > /dev/null" EXIT
@@ -42,6 +65,13 @@ pip install -q -U -r requirements.txt
 echo "Starting ProDG setup script..."
 ./scripts/setup_prodg_linux.sh
 
+## Extract ELF ###
+
+if [ -n "$ISO_ARG" ]; then
+    echo "Extracting executable from ISO..."
+    ./scripts/extract_elf.sh "$ISO_ARG"
+fi
+
 popd > /dev/null
 trap - EXIT
 
@@ -49,8 +79,8 @@ trap - EXIT
 
 echo ""
 echo "Quickstart complete!"
-if [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
-    echo "Now, copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
-fi
 echo ""
+if [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
+    echo "Copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
+fi
 echo "To build the project, run '$(dirname "$0")/build.sh'"

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,43 +1,57 @@
 #!/bin/bash
-
 set -e
 
-# Get script directory
-script_dir=$(dirname $0)
-pushd $script_dir > /dev/null
+### Install Dependencies ###
 
-pip install -U -r ../requirements.txt
+PACKAGES="binutils-mips-linux-gnu ninja-build python3 python3-pip python3-venv wine32"
 
-# Elevate privileges
-sudo -v
-
-# Check if sudo
-if [ "$EUID" -ne 0 ]
-  then echo "Installing dependencies requires sudo. Please enter your password."
+# Install missing dependencies
+if ! sudo -n true 2>/dev/null; then
+    echo "Root privileges are required to install dependencies. Please enter your password."
 fi
 
-# Update apt packages
-sudo apt-get update
+if ! sudo -v; then
+    echo "Error: Unable to obtain root privileges"
+    exit 1
+fi
 
-# Setup wine
+echo "Adding i386 architecture support..."
 sudo dpkg --add-architecture i386
-sudo apt-get update
-sudo apt-get install -y wine32
 
-# Install MIPS assembler
-sudo apt-get install -y binutils-mips-linux-gnu
+echo "Updating package lists..."
+sudo apt-get update -qq > /dev/null
 
-# Install Ninja build system
-sudo apt-get install -y ninja-build
+echo "Dependencies: $PACKAGES"
+echo "Installing missing dependencies..."
+sudo apt-get install -y -qq $PACKAGES > /dev/null
 
-# Setup compiler
-./setup_prodg_linux.sh
+PROJECT_DIR="$(dirname "$0")/.."
 
-# Check if disc/SCUS_971.98 exists
-echo "Setup complete!"
-if [ ! -f ../disc/SCUS_971.98 ]; then
-  echo "Now, copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
-fi
-echo "To build the project, run the 'build.sh' script."
+pushd $PROJECT_DIR > /dev/null
+trap "popd > /dev/null" EXIT
+
+# Set up Python virtual environment
+echo "Setting up Python virtual environment..."
+python3 -m venv env
+source env/bin/activate
+echo "Installing Python packages..."
+pip install -q -U -r requirements.txt
+
+### Download ProDG compilers and runtimes ###
+
+echo "Starting ProDG setup script..."
+./scripts/setup_prodg_linux.sh
 
 popd > /dev/null
+trap - EXIT
+
+### Final Instructions ###
+
+echo ""
+echo "Quickstart complete!"
+if [ ! -f $PROJECT_DIR/disc/SCUS_971.98 ]; then
+    echo "Now, copy SCUS_971.98 from your copy of the game to the 'disc' directory of this project."
+fi
+echo ""
+echo "To enter the python virtual environment, run 'source env/bin/activate' in the project root directory."
+echo "Then, to build the project, run '$(dirname "$0")/build.sh'"

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -22,7 +22,13 @@ Runs a clean reconfigure (deletes build files and splits the binary), then build
 
 ### run.sh
 
-Runs the project in an emulator. Before using, you must edit the script to point to your PCSX2 installation, and the path to your mounted game disc (or backup copy). The script will boot them emulator using the compiled elf, and load the assets from your game disc.
+Runs the last successful build in an emulator. Before using, you must install PCSX2, build the project, and either place an ISO in the `disc` directory or specify one as an argument. The script will boot the emulator using the compiled elf, and load the assets from the provided ISO.
+
+PCSX2 will be auto detected in this order:
+* System PATH
+* Flatpak
+* AppImage in the `tools` directory with "pcsx2" in the file name
+* XDG Desktop entry with "pcsx2" in the file name
 
 ### checks.sh
 

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -20,6 +20,10 @@ There is an equivalent script for Windows, but the assembler does not work on Wi
 
 Runs a clean reconfigure (deletes build files and splits the binary), then builds the project. Will warn you if `disc/SCUS_971.98` is not present.
 
+### diff.sh
+
+Compares a decompiled function against the original using objdiff. Takes a function name as a required argument and an optional object name.
+
 ### run.sh
 
 Runs the last successful build in an emulator. Before using, you must install PCSX2, build the project, and either place an ISO in the `disc` directory or specify one as an argument. The script will boot the emulator using the compiled elf, and load the assets from the provided ISO.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,68 +1,100 @@
 #!/bin/bash
-
-# ##############################################################################
-# Set these paths to point to your PCSX2 1.7 executable and your copy of the game
-PCSX2_PATH=""
-ISO_PATH=""
-# ##############################################################################
-ELF_PATH="out/SCUS_971.98"
-OPTONS="-fastboot -nogui"
-
-# Expand aliases
-shopt -s expand_aliases
-source ~/.bash_aliases > /dev/null
-
-# Exit on error
 set -e
 
-# Print commands as they're run (for debugging)
-#set -o xtrace
+PROJECT_DIR="$(dirname "$0")/.."
+ELF="$PROJECT_DIR/out/SCUS_971.98"
 
-# Function to print an error message and exit
-die() {
-	echo "run.sh: error: $@"
-	exit 1
+# Parse Arguments
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [/path/to/game.iso]" >&2
+    exit 1
+fi
+
+if [[ $# -eq 1 ]]; then
+    ISO="$1"
+else # Find any ISO in disc directory
+    ISO=$(find "$PROJECT_DIR/disc" -maxdepth 1 -type f -iname "*.iso" -print -quit 2>/dev/null)
+    if [[ -z "$ISO" ]]; then
+        echo "Error: No ISO found in $PROJECT_DIR/disc" >&2
+        exit 1
+    fi
+    echo "Using ISO: $(basename "$ISO")"
+fi
+
+# Verify Files
+if [[ ! -f "$ISO" ]]; then
+    echo "Error: ISO not found: $ISO" >&2
+    exit 1
+fi
+
+if [[ ! -f "$ELF" ]]; then
+    echo "Error: ELF not found: $ELF" >&2
+    echo "Build the project first with: ./configure.py && ninja" >&2
+    exit 1
+fi
+
+# Resolve full paths for sandboxed environments
+ISO="$(realpath "$ISO")"
+ELF="$(realpath "$ELF")"
+
+find_pcsx2() {
+    # Check system PATH
+    if command -v pcsx2 &>/dev/null; then
+        printf "pcsx2"
+        return 0
+    fi
+
+    # Check flatpak
+    if command -v flatpak &>/dev/null && flatpak list --app 2>/dev/null | grep -q "net.pcsx2.PCSX2"; then
+        printf "flatpak run net.pcsx2.PCSX2"
+        return 0
+    fi
+
+    # Check for AppImage in tools directory
+    local appimage=$(find "$PROJECT_DIR/tools" -maxdepth 1 -type f -iname "*pcsx2*.appimage" -executable -print -quit 2>/dev/null)
+    if [[ -n "$appimage" ]]; then
+        printf '%q' "$appimage"
+        return 0
+    fi
+
+    # Check XDG Desktop entries
+    local desktop_file=$(find ~/.local/share/applications /usr/share/applications /usr/local/share/applications \
+        -maxdepth 1 -type f -iname "*pcsx2*.desktop" -print -quit 2>/dev/null)
+    if [[ -n "$desktop_file" ]]; then
+        # Extract executable path, stripping env vars and desktop file arguments
+        local exec_line=$(grep -m1 "^Exec=" "$desktop_file" | \
+            sed 's/^Exec=//' | \
+            sed 's/^env //' | \
+            sed 's/[A-Z_][A-Z0-9_]*=[^ ]* *//g' | \
+            sed 's/ %.*//' | \
+            awk '{print $1}')
+        printf '%q' "$exec_line"
+        return 0
+    fi
+
+    return 1
 }
 
-# Error if PCSX2 path is empty
-if [ -z "$PCSX2_PATH" ]; then
-    die PCSX2 path is empty, please edit the paths in 'scripts/run.sh'
+PCSX2=$(find_pcsx2)
+
+if [[ -z "$PCSX2" ]]; then
+    echo "Error: PCSX2 not found. Install it via:" >&2
+    echo "  - System package manager (pcsx2)" >&2
+    echo "  - Flatpak: flatpak install net.pcsx2.PCSX2" >&2
+    echo "  - Download AppImage to $PROJECT_DIR/tools/" >&2
     exit 1
 fi
 
-# Warn if ISO path is empty
-if [ -z "$ISO_PATH" ]; then
-    echo "Warning: ISO path is empty, please edit the paths in 'scripts/run.sh'"
-# Error if ISO path is not valid
-elif [ -f "$ISO_PATH" ]; then
-    die Game ISO not found at $ISO_PATH
-    exit 1
+run_verbose() {
+    ( PS4=''; set -x; "$@" )
+}
+
+# Grant Flatpak Permissions
+if [[ "$PCSX2" == "flatpak run"* ]]; then
+    run_verbose flatpak override --user net.pcsx2.PCSX2 \
+        --filesystem="$ISO":ro \
+        --filesystem="$ELF":ro
 fi
 
-# Error if PCSX2 is not valid
-#if [ -f "$PCSX2_PATH" ]; then
-#    die PCSX2 executable not found at $PCSX2_PATH
-#    exit 1
-#fi
-
-# Show error message if PCSX2 is not executable
-#if [ -x "$PCSX2_PATH" ]; then
-#    die PCSX2 executable is not executable
-#    exit 1
-#fi
-
-# Switch to the project root directory
-pushd "$(dirname "$0")/.." > /dev/null
-
-# Build the game
-echo Compiling ELF...
-#python3 configure.py --clean
-ninja
-
-# Run the game
-echo Booting ELF in PCSX2...
-"$PCSX2_PATH" -elf $ELF_PATH $OPTIONS -- $ISO_PATH
-
-# Switch back to the original directory
-popd > /dev/null
-echo Done.
+# Launch PCSX2
+run_verbose $PCSX2 -elf "$ELF" -fastboot -nogui -- "$ISO"

--- a/scripts/setup_prodg_linux.sh
+++ b/scripts/setup_prodg_linux.sh
@@ -1,38 +1,19 @@
 #!/bin/bash
-
 # Sets up the ProDG compilers + SCE Runtime Library to build the project.
-
 set -e
 
-WINE_ROOT=~/.wine/drive_c
 TOP=$(cd "$(dirname "$0")"; pwd)/..
-
-# The SDK (Runtime Library) version to install.
-SDK_VER=242
-
-die() { # perl-style `die` expressions.
-	echo "Error: $@"
-	exit 1
-}
 
 # downloads files without checking integrity
 download() {
 	echo "Downloading $1..."
 	wget -qP /tmp $1
-
-	BASENAME=$(basename $1)
-
-	#echo "moving files out of /tmp"
-	#mv /tmp/$BASENAME $TOP
 }
 
 echo Starting ProDG setup script...
 
 # download required files (registry + SDK package)
 download "https://github.com/TheOnlyZac/compilers/releases/download/ee-gcc2.95.2-SN-v2.73a/ee-gcc2.95.2-SN-v2.73a.tar.gz"
-
-# apply environment variables from the registry file
-# wine regedit prodg_env.reg
 
 # Extract the compiler into the tools dir
 echo "Extracting compiler to $TOP/tools..."
@@ -41,4 +22,4 @@ tar -xzf /tmp/ee-gcc2.95.2-SN-v2.73a.tar.gz -C $TOP/tools
 echo "Removing temporary files..."
 rm /tmp/ee-gcc2.95.2-SN-v2.73a.tar.gz
 
-echo "Setup complete!"
+echo "ProDG setup complete!"

--- a/scripts/setup_prodg_linux.sh
+++ b/scripts/setup_prodg_linux.sh
@@ -2,24 +2,10 @@
 # Sets up the ProDG compilers + SCE Runtime Library to build the project.
 set -e
 
-TOP=$(cd "$(dirname "$0")"; pwd)/..
+PROJECT_DIR="$(dirname "$0")/.."
+TOOLS_DIR="$PROJECT_DIR/tools"
+DOWNLOAD_URL="https://github.com/TheOnlyZac/compilers/releases/download/ee-gcc2.95.2-SN-v2.73a/ee-gcc2.95.2-SN-v2.73a.tar.gz"
 
-# downloads files without checking integrity
-download() {
-	echo "Downloading $1..."
-	wget -qP /tmp $1
-}
-
-echo Starting ProDG setup script...
-
-# download required files (registry + SDK package)
-download "https://github.com/TheOnlyZac/compilers/releases/download/ee-gcc2.95.2-SN-v2.73a/ee-gcc2.95.2-SN-v2.73a.tar.gz"
-
-# Extract the compiler into the tools dir
-echo "Extracting compiler to $TOP/tools..."
-tar -xzf /tmp/ee-gcc2.95.2-SN-v2.73a.tar.gz -C $TOP/tools
-
-echo "Removing temporary files..."
-rm /tmp/ee-gcc2.95.2-SN-v2.73a.tar.gz
-
+echo "Downloading compiler..."
+wget -q -O - "$DOWNLOAD_URL" | tar -xz -C "$TOOLS_DIR"
 echo "ProDG setup complete!"


### PR DESCRIPTION
Since the quickstart script was almost completely nonfunctional I took it upon myself to rewrite it, and then got a bit carried away and rewrote all the scripts from scratch. I'm happy to say the intended functionality has been restored along with a bunch of new features:

- Quickstart will auto extract the game executable if it finds an ISO in the `disc` directory or if a path to one is provided as an argument.
- All scripts assume you are outside the python venv and enter it automatically when necessary. There should be no reason to manually enter the venv outside of manual setup. You can still enter it manually if you want to of course.
- New diff script to build objects and run objdiff with a single command.
- Run script now automatically finds and launches PCSX2 in this search order: 
  - PATH (Installed via package manager)
  - Flatpak
  - AppImage with a name containing "pcsx2" in the `tools` directory
  - XDG Desktop Entry with a name containing "pcsx2" (Common for AppImage "Installers")

  and boots the last built ELF using the first ISO it finds in the `disc` directory or a specified ISO for assets.
- Various fixes to the readme unrelated to my changes

All this results in a workflow that gets you from a git clone in a fresh debian container to a built executable in under 90 seconds!

<img width="1679" height="1294" alt="image" src="https://github.com/user-attachments/assets/c28f39d1-0e0e-4500-bfa0-a62a4a3ca0ea" />


<img width="438" height="204" alt="image" src="https://github.com/user-attachments/assets/48507070-cfa1-4659-a281-1705ff67fa3b" />
