### PR TITLE
Replace nullptr with NULL

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -6,6 +6,8 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include <stddef.h>
+
 // Exact-width integers (don't use these in most cases)
 typedef signed char      int8_t;
 typedef short            int16_t;
@@ -31,7 +33,6 @@ typedef ulong   undefined8;
 
 // Misc
 typedef uchar byte;
-#define nullptr (void *)0x0
 typedef union QW;
 
 #endif // TYPES_H

--- a/src/P2/989snd.c
+++ b/src/P2/989snd.c
@@ -4,8 +4,6 @@
 #include <sdk/ee/sifrpc.h>
 #include <sdk/libcdvd.h>
 
-#include <stddef.h>
-
 #include <common.h>
 #include <text.h>
 

--- a/src/P2/ac.c
+++ b/src/P2/ac.c
@@ -12,7 +12,7 @@ void GetAcpTimes(ACP *pacp, int *pct, float **pat)
     *pct = 0;
     if (pat)
     {
-        *pat = (float *)nullptr;
+        *pat = NULL;
     }
 }
 
@@ -31,7 +31,7 @@ void GetAcrTimes(ACR *pacr, int *pct, float **pat)
     *pct = 0;
     if (pat)
     {
-        *pat = (float *)nullptr;
+        *pat = NULL;
     }
 }
 
@@ -45,7 +45,7 @@ void GetAcsTimes(ACS *pacs, int *pct, float **pat)
     *pct = 0;
     if (pat)
     {
-        *pat = (float *)nullptr;
+        *pat = NULL;
     }
 }
 
@@ -59,7 +59,7 @@ void GetAcgTimes(ACG *pacg, int *pct, float **pat)
     *pct = 0;
     if (pat)
     {
-        *pat = (float *)nullptr;
+        *pat = NULL;
     }
 }
 

--- a/src/P2/actseg.c
+++ b/src/P2/actseg.c
@@ -8,7 +8,7 @@ void RetractActseg(ACTSEG *pactseg, GRFRA grfra)
 
     if (pasega->pactsegError == pactseg)
     {
-        pasega->pactsegError = (ACTSEG *)nullptr;
+        pasega->pactsegError = NULL;
     }
 
     RetractAct(pactseg, grfra);

--- a/src/P2/alo.c
+++ b/src/P2/alo.c
@@ -267,7 +267,7 @@ SHADOW *PshadowInferAlo(ALO *palo)
 void GetAloCastShadow(ALO *palo, int *pfCastShadow)
 {
     // palo->pshadow
-    *pfCastShadow = (STRUCT_OFFSET(palo, 0x284, SHADOW *) != (SHADOW *)nullptr);
+    *pfCastShadow = (STRUCT_OFFSET(palo, 0x284, SHADOW *) != NULL);
 }
 
 void GetAloShadowShader(ALO *palo, OID *poidShdShadow)

--- a/src/P2/aseg.c
+++ b/src/P2/aseg.c
@@ -25,13 +25,13 @@ INCLUDE_ASM("asm/nonmatchings/P2/aseg", ApplyAsegOvr__FP4ASEGP3ALOiP3OVRffiPP5AS
 
 void ApplyAseg(ASEG *paseg, ALO *paloAsegRoot, float tLocal, float svtLocal, GRFAPL grfapl, ASEGA **ppasega)
 {
-    ApplyAsegOvr(paseg, paloAsegRoot, 0, (OVR *)nullptr, tLocal, svtLocal, grfapl, ppasega);
+    ApplyAsegOvr(paseg, paloAsegRoot, 0, NULL, tLocal, svtLocal, grfapl, ppasega);
 }
 
 ASEGA *PasegaApplyAseg(ASEG *paseg, ALO *paloAsegRoot, float tLocal, float svtLocal, GRFAPL grfapl)
 {
     ASEGA *pasega;
-    ApplyAsegOvr(paseg, paloAsegRoot, 0, (OVR *)nullptr, tLocal, svtLocal, grfapl, &pasega);
+    ApplyAsegOvr(paseg, paloAsegRoot, 0, NULL, tLocal, svtLocal, grfapl, &pasega);
     return pasega;
 }
 
@@ -51,7 +51,7 @@ void ApplyAsegCur(ASEG *paseg, ALO *paloRoot, float t, float svt, GRFAPL grfapl,
     if (*ppasega)
     {
         RetractAsega(*ppasega);
-        *ppasega = (ASEGA *)nullptr;
+        *ppasega = NULL;
     }
     if (paseg)
     {

--- a/src/P2/barrier.c
+++ b/src/P2/barrier.c
@@ -4,7 +4,7 @@
 void InitBarrier(BARRIER *pbarrier)
 {
     InitSo(pbarrier);
-    SetSoConstraints(pbarrier, CT_Locked, (VECTOR *)nullptr, CT_Locked, (VECTOR *)nullptr);
+    SetSoConstraints(pbarrier, CT_Locked, NULL, CT_Locked, NULL);
     STRUCT_OFFSET(pbarrier, 0x590, OID) = OID_Nil; // pbarrier->barwarp.oidWarp
 }
 

--- a/src/P2/bas.c
+++ b/src/P2/bas.c
@@ -8,8 +8,8 @@ CBinaryAsyncStream::CBinaryAsyncStream(void *pvSpool)
     m_isector = 0;
     m_abSpool = (byte *)(((int)pvSpool + 0x3f) & ~0x3f);
     m_fd = -1;
-    m_pbSpooling = (byte *)nullptr;
-    m_pb = (byte *)nullptr;
+    m_pbSpooling = NULL;
+    m_pb = NULL;
     m_cbFile = 0;
     m_cbUnspooled = 0;
     m_cbSpooling = 0;

--- a/src/P2/bbmark.c
+++ b/src/P2/bbmark.c
@@ -7,7 +7,7 @@ INCLUDE_ASM("asm/nonmatchings/P2/bbmark", UpdateSwPox__FP2SWP3OXAT1UcUc);
 OX *PoxAddSw(SW *psw, OXA *poxa, OXA *poxaOther)
 {
     OX *pox = (OX *)PvAllocSlotheapImpl(&psw->slotheapOx);
-    pox->pxp = (XP *)nullptr;
+    pox->pxp = NULL;
     pox->psoOther = poxaOther->pso;
     pox->poxNext = poxa->pox;
     poxa->pox = pox;
@@ -21,7 +21,7 @@ INCLUDE_ASM("asm/nonmatchings/P2/bbmark", PoxFromSoSo__FP2SOT0);
 XP *PxpFirstFromSoSo(SO *pso, SO *psoOther)
 {
     OX *pox = PoxFromSoSo(pso, psoOther);
-    return pox ? pox->pxp : (XP *)nullptr;
+    return pox ? pox->pxp : NULL;
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/bbmark", AddSwAaobrObject__FP2SWP2SO);

--- a/src/P2/binoc.c
+++ b/src/P2/binoc.c
@@ -17,7 +17,7 @@ void InitBinoc(BINOC *binoc, BLOTK blotk)
 void ResetBinoc(BINOC *binoc)
 {
     binoc->pvtbinoc->pfnSetBinocAchzDraw(binoc, 0);
-    SetBinocLookat(binoc, (ALO *)0);
+    SetBinocLookat(binoc, NULL);
     binoc->dxReticle = 0.0f;
     binoc->dyReticle = 0.0f;
     binoc->uCompassBarOffset = 0.4f;

--- a/src/P2/bis.c
+++ b/src/P2/bis.c
@@ -201,7 +201,7 @@ void CBinaryInputStream::Read(int cb, void *pv)
             if ((int)uVar1 <= cb) {
                 cb_00 = uVar1;
             }
-            if (pv != nullptr) {
+            if (pv != NULL) {
                 byte* pb = reinterpret_cast<byte*>(pv);
                 CopyAb(pb, m_pb, cb_00);
                 pv = reinterpret_cast<void*>(pb + cb_00);
@@ -432,7 +432,7 @@ JUNK_ADDIU(50);
 void CBinaryInputStream::Unknown1()
 {
     ushort size = U16Read();
-    Read(size, (void *)nullptr);
+    Read(size, NULL);
 }
 
 void CBinaryInputStream::Unknown2(void **ppv)
@@ -446,5 +446,5 @@ void CBinaryInputStream::Unknown2(void **ppv)
         return;
     }
 
-    *ppv = (void *)nullptr;
+    *ppv = NULL;
 }

--- a/src/P2/break.c
+++ b/src/P2/break.c
@@ -10,7 +10,7 @@ INCLUDE_ASM("asm/nonmatchings/P2/break", CloneBrk__FP3BRKT0);
 void PostBrkLoad(BRK *pbrk)
 {
     PostAloLoad((ALO *)pbrk);
-    PostSwCallback(pbrk->psw, PostBrkLoadCallbackHookup, pbrk, MSGID_callback, nullptr);
+    PostSwCallback(pbrk->psw, PostBrkLoadCallbackHookup, pbrk, MSGID_callback, NULL);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/break", PostBrkLoadCallbackHookup__FP3BRK5MSGIDPv);

--- a/src/P2/button.c
+++ b/src/P2/button.c
@@ -1,6 +1,5 @@
 #include <button.h>
 #include <chkpnt.h>
-#include <stddef.h>
 
 INCLUDE_ASM("asm/nonmatchings/P2/button", PostAshLoad__FP2SWP3ASHP3ALO);
 
@@ -44,7 +43,7 @@ void TriggerBtn(BTN *pbtn, int fSeekToEnd, int fChkTrigger)
         float sStart = 3000.0f;
         float sFull = 300.0f;
         float uVolAtSource = 1.0f;
-        StartSound(SFXID_Click1, 0, pbtn->paloOwner, NULL, sStart, sFull, uVolAtSource, 0.0f,
+        StartSound(SFXID_Click1, NULL, pbtn->paloOwner, NULL, sStart, sFull, uVolAtSource, 0.0f,
                    0.0f, NULL, NULL);
     }
 

--- a/src/P2/cm.c
+++ b/src/P2/cm.c
@@ -45,7 +45,7 @@
 // float D_00261988 = 250.0f;
 // float D_0026198C = 0.0f;
 
-// CM* g_pcm = (CM *)0x0;
+// CM* g_pcm = NULL;
 
 void StartupCm()
 {
@@ -95,12 +95,12 @@ INCLUDE_ASM("asm/nonmatchings/P2/cm", FUN_001438d8);
 
 void SetCmPos(CM *pcm, VECTOR *ppos)
 {
-    SetCmPosMat(pcm, ppos, 0x0);
+    SetCmPosMat(pcm, ppos, NULL);
 }
 
 void SetCmMat(CM *pcm, MATRIX3 *pmat)
 {
-    SetCmPosMat(pcm, 0x0, pmat);
+    SetCmPosMat(pcm, NULL, pmat);
 }
 
 void SetCmFov(CM *pcm, float fov)

--- a/src/P2/coin.c
+++ b/src/P2/coin.c
@@ -152,9 +152,9 @@ void SetCharmDprizes(CHARM *pcharm, DPRIZES dprizes)
     if (dprizes == DPRIZES_Collect)
     {
         dprizes = DPRIZES_Swirl;
-        StartSound(SFXID_Collect_Charm, (AMB **)0x0, pcharm, (VECTOR *) 0x0,
-                   1500.0f, 0.0f,1, 0.0f, 0.0f, (LM *)0x0, (LM *)0x0);
-        HandleLoSpliceEvent(pcharm, 2, 0, 0);
+        StartSound(SFXID_Collect_Charm, NULL, pcharm, NULL, 1500.0f, 0.0f, 1, 0.0f, 0.0f, NULL,
+                   NULL);
+        HandleLoSpliceEvent(pcharm, 2, 0, NULL);
     }
 
     SetDprizeDprizes(pcharm, dprizes);

--- a/src/P2/dart.c
+++ b/src/P2/dart.c
@@ -38,7 +38,7 @@ void HandleDartMessage(DART *pdart, MSGID msgid, void *pv)
     // pdart->pasegaSticking
     if (msgid == MSGID_asega_retracted && (ASEGA *)pv == STRUCT_OFFSET(pdart, 0x578, ASEGA *))
     {
-        STRUCT_OFFSET(pdart, 0x578, ASEGA *) = (ASEGA *)nullptr;
+        STRUCT_OFFSET(pdart, 0x578, ASEGA *) = NULL;
         SetDartDarts(pdart, DARTS_Stuck);
     }
 }
@@ -91,10 +91,10 @@ void SetDartDarts(DART *pdart, DARTS darts)
 
     if (STRUCT_OFFSET(pdart, 0x550, DARTS) == DARTS_Airborne)
     {
-        STRUCT_OFFSET(pdart, 0x57c, ALO *) = (ALO *)nullptr; // pdart->paloTarget
+        STRUCT_OFFSET(pdart, 0x57c, ALO *) = NULL; // pdart->paloTarget
         STRUCT_OFFSET(pdart, 0x580, float) = 0.0f; // pdart->dtLaunchToTarget
         STRUCT_OFFSET(pdart, 0x584, float) = 0.0f; // pdart->dzTarget
-        STRUCT_OFFSET(pdart, 0x588, DARTGUN *) = (DARTGUN *)nullptr; // pdart->pdartgunFiredFrom
+        STRUCT_OFFSET(pdart, 0x588, DARTGUN *) = NULL; // pdart->pdartgunFiredFrom
     }
 
     STRUCT_OFFSET(pdart, 0x550, DARTS) = darts; // pdart->darts

--- a/src/P2/dialog.c
+++ b/src/P2/dialog.c
@@ -56,7 +56,7 @@ void HandleDialogMessage(DIALOG *pdialog, MSGID msgid, void *pv)
     // pdialog->dp
     if (msgid == MSGID_asega_retracted && (ASEGA *)pv == STRUCT_OFFSET(pdialog, 0x2e8, DP).pasegaLipsync)
     {
-        STRUCT_OFFSET(pdialog, 0x2e8, DP).pasegaLipsync = (ASEGA *)nullptr;
+        STRUCT_OFFSET(pdialog, 0x2e8, DP).pasegaLipsync = NULL;
     }
 }
 

--- a/src/P2/dl.c
+++ b/src/P2/dl.c
@@ -9,14 +9,14 @@ void InitDl(DL *pdl, int ibDle)
 
 void ClearDl(DL *pdl)
 {
-    pdl->tail = nullptr;
-    pdl->head = nullptr;
+    pdl->tail = NULL;
+    pdl->head = NULL;
 }
 
 void ClearDle(DLE *pdle)
 {
-    pdle->prev = nullptr;
-    pdle->next = nullptr;
+    pdle->prev = NULL;
+    pdle->next = NULL;
 }
 
 DLE *PdleFromDlEntry(DL *pdl, void *pv)
@@ -133,8 +133,8 @@ void RemoveDlEntry(DL *pdl, void *pv)
     }
 
     // Clear links
-    pentry->next = nullptr;
-    pentry->prev = nullptr;
+    pentry->next = NULL;
+    pentry->prev = NULL;
 }
 
 bool FFindDlEntry(DL *pdl, void *pv)

--- a/src/P2/dmas.c
+++ b/src/P2/dmas.c
@@ -28,15 +28,15 @@ DMAS::DMAS()
 
 void DMAS::Clear()
 {
-    m_pbMax = (uchar *)nullptr;
-    m_ab = (uchar *)nullptr;
-    m_pqwCnt = (QW *)nullptr;
-    m_pb = (uchar *)nullptr;
+    m_pbMax = NULL;
+    m_ab = NULL;
+    m_pqwCnt = NULL;
+    m_pb = NULL;
 }
 
 void DMAS::Reset()
 {
-    m_pqwCnt = (QW *)nullptr;
+    m_pqwCnt = NULL;
     m_pb = m_ab;
 }
 

--- a/src/P2/find.c
+++ b/src/P2/find.c
@@ -72,5 +72,5 @@ ALO *PaloFindLoCommonParent(LO *plo, LO *ploOther)
         plo = (LO *)plo->paloParent;
     }
 
-    return (ALO *)nullptr;
+    return NULL;
 }

--- a/src/P2/font.c
+++ b/src/P2/font.c
@@ -2,7 +2,7 @@
 
 void StartupFont()
 {
-    g_pfont = (CFont *)nullptr;
+    g_pfont = NULL;
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/font", FUN_0015c188);

--- a/src/P2/geom.c
+++ b/src/P2/geom.c
@@ -3,13 +3,13 @@
 void InitGeom(GEOM *pgeom)
 {
     pgeom->cpos = 0;
-    pgeom->apos = (VECTOR *)nullptr;
+    pgeom->apos = NULL;
 
     pgeom->csurf = 0;
-    pgeom->asurf = (SURF *)nullptr;
+    pgeom->asurf = NULL;
 
     pgeom->cedge = 0;
-    pgeom->aedge = (EDGE *)nullptr;
+    pgeom->aedge = NULL;
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/geom", CloneGeom__FP4GEOMP7MATRIX4T0);

--- a/src/P2/glbs.c
+++ b/src/P2/glbs.c
@@ -32,7 +32,7 @@ void GLBS::FindLights(VECTOR *ppos, float sRadius)
 
 void GLBS::ResetStrip()
 {
-    m_pshd = (SHD *)nullptr;
+    m_pshd = NULL;
     m_cvtxg = 0;
     memset(m_avtxg, 0, 148 * sizeof(VTXG));
 }

--- a/src/P2/jlo.c
+++ b/src/P2/jlo.c
@@ -19,7 +19,7 @@ void InitJlo(JLO *pjlo)
     STRUCT_OFFSET(psmp, 0x04, float) = 0.0f; // pjlo->smpSpin.svSlow
     STRUCT_OFFSET(psmp, 0x08, float) = 0.25f; // pjlo->smpSpin.dtFast
 
-    g_pjloCur = (JLO *)nullptr;
+    g_pjloCur = NULL;
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/jlo", LoadJloFromBrx__FP3JLOP18CBinaryInputStream);
@@ -66,7 +66,7 @@ void ActivateJlo(JLO *pjlo)
 
 void DeactivateJlo(JLO *pjlo)
 {
-    g_pjloCur = (JLO *)nullptr;
+    g_pjloCur = NULL;
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/jlo", InitJloc__FP4JLOC);

--- a/src/P2/jsg.c
+++ b/src/P2/jsg.c
@@ -57,7 +57,7 @@ void ApplyJsg(JSG *pjsg, JT *pjt)
     pjsg->pjt = pjt;
     pjsg->ijsgeCur = -1;
 
-    HandleLoSpliceEvent(pjsg, 0x17, 0, (void **)nullptr);
+    HandleLoSpliceEvent(pjsg, 0x17, 0, NULL);
 
     if (pjsg->unk3)
     {
@@ -71,8 +71,8 @@ void RetractJsg(JSG *pjsg)
     if (!pjsg->pjt)
         return;
 
-    SetJsgTn(pjsg, (TN *)nullptr);
-    SetJsgFocus(pjsg, (LO *)nullptr);
+    SetJsgTn(pjsg, NULL);
+    SetJsgFocus(pjsg, NULL);
 
     if (pjsg->pasegaCur)
     {
@@ -82,12 +82,12 @@ void RetractJsg(JSG *pjsg)
 
     SetClockRate(1.0f);
     pjsg->ijsgeCur = pjsg->cjsge;
-    pjsg->ploContext = (LO *)nullptr;
-    pjsg->pjsgeJoy = (JSGE *)nullptr;
-    STRUCT_OFFSET(pjsg->pjt, 0x2740, JSG *) = (JSG *)nullptr; // pjsg->pjt->pjsgCur
-    pjsg->pjt = (JT *)nullptr;
+    pjsg->ploContext = NULL;
+    pjsg->pjsgeJoy = NULL;
+    STRUCT_OFFSET(pjsg->pjt, 0x2740, JSG *) = NULL; // pjsg->pjt->pjsgCur
+    pjsg->pjt = NULL;
 
-    HandleLoSpliceEvent(pjsg, 0x19, 0, 0);
+    HandleLoSpliceEvent(pjsg, 0x19, 0, NULL);
 
     if (pjsg->unk3)
     {

--- a/src/P2/lo.c
+++ b/src/P2/lo.c
@@ -21,7 +21,7 @@ void InitLo(LO *plo)
 
 void PostLoLoad(LO *plo)
 {
-    HandleLoSpliceEvent(plo, 0, 0, (void **)nullptr);
+    HandleLoSpliceEvent(plo, 0, 0, NULL);
 }
 
 void AddLo(LO *plo)
@@ -128,7 +128,7 @@ int FFindLoParent(LO *plo, ALO *paloParent)
         plo = plo->paloParent;
     }
 
-    return (paloParent == nullptr);
+    return (paloParent == NULL);
 }
 
 void SetLoParent(LO *plo, ALO *paloParent)
@@ -239,7 +239,7 @@ void UnsubscribeSwPpmqStruct(SW *psw, MQ **ppmqFirst, PFNMQ pfnmq, void *pvConte
         if (pmq->pfnmq == pfnmq && pmq->pvContext == pvContext)
         {
             *ppmqFirst = pmq->pmqNext;
-            pmq->pmqNext = (MQ*)nullptr;
+            pmq->pmqNext = NULL;
             pmqTarget = pmq;
             FreeSwMqList(psw, pmqTarget);
             break;

--- a/src/P2/main.c
+++ b/src/P2/main.c
@@ -76,7 +76,7 @@ static SFN s_asfn[29] =
  * @todo Are these the right way around?
  */
 int g_cpchzArgs = 0;
-char **g_apchzArgs = (char **)nullptr;
+char **g_apchzArgs = NULL;
 
 /**
  * @brief Main function.

--- a/src/P2/memory.c
+++ b/src/P2/memory.c
@@ -70,7 +70,7 @@ void *PvAllocSwImpl(int cb)
 {
     if (cb == 0)
     {
-        return nullptr;
+        return NULL;
     }
 
     CheckForOutOfMemory();
@@ -116,7 +116,7 @@ void *PvAllocStackImpl(int cb)
 {
     if (cb == 0)
     {
-        return nullptr;
+        return NULL;
     }
 
     CheckForOutOfMemory();
@@ -143,12 +143,12 @@ void FreeStackImpl()
 
 void *malloc(uint __size)
 {
-    return nullptr;
+    return NULL;
 }
 
 void *_malloc_r(_reent *pre, uint __size)
 {
-    return nullptr;
+    return NULL;
 }
 
 void free(void *pv)

--- a/src/P2/mrkv.c
+++ b/src/P2/mrkv.c
@@ -4,5 +4,5 @@ void InitMrkv(MRKV *pmrkv)
 {
     InitSo(pmrkv);
     STRUCT_OFFSET(pmrkv, 0x538, ulong) = STRUCT_OFFSET(pmrkv, 0x538, ulong) | 0x80000000000;
-    SetSoConstraints(pmrkv, CT_Locked, (VECTOR *)nullptr, CT_Locked, (VECTOR *)nullptr);
+    SetSoConstraints(pmrkv, CT_Locked, NULL, CT_Locked, NULL);
 }

--- a/src/P2/pnt.c
+++ b/src/P2/pnt.c
@@ -9,7 +9,7 @@ void LoadPntFromBrx(PNT *ppnt, CBinaryInputStream *pbis)
 
 void GetPntPos(PNT *ppnt, VECTOR *ppos)
 {
-    ConvertAloPos(ppnt->paloParent, (ALO *)nullptr, &ppnt->posLocal, ppos);
+    ConvertAloPos(ppnt->paloParent, NULL, &ppnt->posLocal, ppos);
 }
 
 void SetPntParent(PNT *ppnt, ALO *paloParent)
@@ -20,7 +20,7 @@ void SetPntParent(PNT *ppnt, ALO *paloParent)
 
 void ApplyPntProxy(PNT *ppnt, PROXY *pproxyApply)
 {
-    ConvertAloPos((ALO *)pproxyApply, (ALO *)nullptr, &ppnt->posLocal, &ppnt->posLocal);
+    ConvertAloPos((ALO *)pproxyApply, NULL, &ppnt->posLocal, &ppnt->posLocal);
 }
 
 /**

--- a/src/P2/po.c
+++ b/src/P2/po.c
@@ -66,7 +66,7 @@ PO *PpoCur()
 {
     if (g_ippoCur < 0)
     {
-        return (PO *)nullptr;
+        return NULL;
     }
 
 	return g_appo[g_ippoCur];

--- a/src/P2/prog.c
+++ b/src/P2/prog.c
@@ -105,7 +105,7 @@ void CProg::Draw() {
     gifs.AddPrimEnd();
     gifs.AddDmaEnd();
     gifs.EndDmaCnt();
-    gifs.Detach(0x0, 0x0);
+    gifs.Detach(NULL, NULL);
     BlastAqwGifsBothFrames(aqwProgress);
 }
 #endif

--- a/src/P2/screen.c
+++ b/src/P2/screen.c
@@ -108,10 +108,10 @@ INCLUDE_ASM("asm/nonmatchings/P2/screen", DrawTimer__FP5TIMER);
 void SetTimer(TIMER *ptimer, float dt)
 {
     float threshold = D_0024CD4C;
-    ptimer->pfntnThreshold = (undefined1 *)0;
+    ptimer->pfntnThreshold = NULL;
     ptimer->fThreshold = 0;
     ptimer->dtExpire = 0.0;
-    ptimer->pfntnExpire = (undefined1 *)0;
+    ptimer->pfntnExpire = NULL;
     ptimer->fStopped = 0;
     *(int*)&ptimer->rgba = 0xff808080; // Union?
     ptimer->svt = -1.0;

--- a/src/P2/sensor.c
+++ b/src/P2/sensor.c
@@ -47,7 +47,7 @@ void SetSensorSensors(SENSOR *psensor, SENSORS sensors)
 		}
 	}
 
-	HandleLoSpliceEvent(psensor, 2, 0, (void **)0);
+	HandleLoSpliceEvent(psensor, 2, 0, NULL);
 	STRUCT_OFFSET(psensor, 0x558, SENSORS) = sensors; // psensor->sensors = sensors;
 	STRUCT_OFFSET(psensor, 0x55C, float) = g_clock.t;
 }

--- a/src/P2/slotheap.c
+++ b/src/P2/slotheap.c
@@ -15,7 +15,7 @@ void _InitSlotheap(SLOTHEAP *pslotheap, int cb, int c)
         pslotPrev->pslotNext = (SLOT *)pbBase;
     }
 
-    ((SLOT *)pbBase)->pslotNext = (SLOT *)nullptr;
+    ((SLOT *)pbBase)->pslotNext = NULL;
 }
 
 void CreateSlotheapSw(SLOTHEAP *pslotheap, int cb, int c)

--- a/src/P2/sm.c
+++ b/src/P2/sm.c
@@ -8,7 +8,7 @@ void PostSmLoad(SM *psm)
     PostLoLoad(psm);
     if (psm->fDefault)
     {
-        PostSwCallback(psm->psw, PostSmLoadCallback, psm, MSGID_callback, nullptr);
+        PostSwCallback(psm->psw, PostSmLoadCallback, psm, MSGID_callback, NULL);
     }
 }
 

--- a/src/P2/smartguard.c
+++ b/src/P2/smartguard.c
@@ -49,6 +49,6 @@ void FreezeSmartguard(SMARTGUARD *psmartguard, int fFreeze)
     {
         // psmartguard->pexcSneak
         UnsetExcitement(STRUCT_OFFSET(psmartguard, 0xcc0, EXC *));
-        STRUCT_OFFSET(psmartguard, 0xcc0, EXC *) = (EXC *)nullptr;
+        STRUCT_OFFSET(psmartguard, 0xcc0, EXC *) = NULL;
     }
 }

--- a/src/P2/so.c
+++ b/src/P2/so.c
@@ -133,7 +133,7 @@ INCLUDE_ASM("asm/nonmatchings/P2/so", SetSoSphere__FP2SOf);
 
 void SetSoNoInteract(SO *pso, int fNoInteract)
 {
-    SetSoConstraints(pso, CT_Locked, (VECTOR *)nullptr, CT_Locked, (VECTOR *)nullptr);
+    SetSoConstraints(pso, CT_Locked, NULL, CT_Locked, NULL);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/so", ConstrFromCnstr__F5CNSTRP2CTP6VECTOR);

--- a/src/P2/splice/gc.cpp
+++ b/src/P2/splice/gc.cpp
@@ -48,7 +48,7 @@ CFrame *CGc::PframePop()
     {
         return m_apframeStack[--m_cpframeStack];
     }
-    return (CFrame *)nullptr;
+    return NULL;
 }
 
 void CGc::PushPair(CPair *ppair)
@@ -62,7 +62,7 @@ CPair *CGc::PpairPop()
     {
         return m_appairStack[--m_cppairStack];
     }
-    return (CPair *)nullptr;
+    return NULL;
 }
 
 void CGc::PushProc(CProc *pproc)
@@ -76,7 +76,7 @@ CProc *CGc::PprocPop()
     {
         return m_approcStack[--m_cpprocStack];
     }
-    return (CProc *)nullptr;
+    return NULL;
 }
 
 void CGc::UpdateRecyclable()

--- a/src/P2/splice/splotheap.cpp
+++ b/src/P2/splice/splotheap.cpp
@@ -23,10 +23,10 @@ void CSplotheap::Startup(int cb, int c)
         psplotPrev->psplotNext = psplotCurr;
     }
 
-    psplotCurr->psplotNext = (SPLOT *)nullptr;
+    psplotCurr->psplotNext = NULL;
 
-    m_psplotAlloc = (SPLOT *)nullptr;
-    m_psplotRecyclable = (SPLOT *)nullptr;
+    m_psplotAlloc = NULL;
+    m_psplotRecyclable = NULL;
 }
 #endif // SKIP_ASM
 
@@ -51,7 +51,7 @@ void *CSplotheap::PvAllocUnsafe()
         return PvFromPsplot(psplot);
     }
 
-    return nullptr;
+    return NULL;
 }
 
 void *CSplotheap::PvAllocClear()

--- a/src/P2/steppower.c
+++ b/src/P2/steppower.c
@@ -97,7 +97,7 @@ void UpdateJtActivePowerUp(JT *pjt, JOY *pjoy)
     {
     case FSP_Dive:
         // Only rotate if JT is rushing or ledge grabbing.
-        if (g_pjt == nullptr
+        if (g_pjt == NULL
             || g_pjt->jts != JTS_Rush
             || !g_pjt->jts == JTS_Jump && g_pjt->jtbs == (JTBS)0x8)
         {
@@ -110,7 +110,7 @@ void UpdateJtActivePowerUp(JT *pjt, JOY *pjoy)
         break;
     case FSP_Ball:
         // Only rotate if JT is not rolling.
-        if (g_pjt != nullptr
+        if (g_pjt != NULL
             && !(g_pjt->jts == JTS_Ball && g_pjt->jtbs == (JTBS)0xd))
             {
                 fcanRotate = true;
@@ -152,7 +152,7 @@ void UpdateJtActivePowerUp(JT *pjt, JOY *pjoy)
     }
 
     // Disallow rotating if JT status is Zap or binoc is showing.
-    if (g_pjt != nullptr && g_pjt->jts == JTS_Zap)
+    if (g_pjt != NULL && g_pjt->jts == JTS_Zap)
         fcanRotate = false;
 
     if (g_binoc.blots != BLOTS_Hidden)
@@ -234,7 +234,7 @@ void UpdateJtActivePowerUp(JT *pjt, JOY *pjoy)
     case FSP_Mine:
         if (pjt->jts < (JTS)2
             && JOY_BUTTON_PRESSED(pjoy, PAD_TRIANGLE)
-            && STRUCT_OFFSET(pjt, 0x1518, LO *) != nullptr)
+            && STRUCT_OFFSET(pjt, 0x1518, LO *) != NULL)
         {
             SetJoyBtnHandled(pjoy, PAD_TRIANGLE);
             LO *ploMine = STRUCT_OFFSET(pjt, 0x1518, LO *);

--- a/src/P2/text.c
+++ b/src/P2/text.c
@@ -102,7 +102,7 @@ extern "C" char *strchr(char *pchz, int ch)
         }
         pchz++;
     }
-    return (char *)nullptr;
+    return NULL;
 }
 
 JUNK_NOP();

--- a/src/P2/tn.c
+++ b/src/P2/tn.c
@@ -12,7 +12,7 @@ void OnTnRemove(TN *ptn)
 {
     OnAloRemove(ptn);
     SetTnTns(ptn, TNS_Out);
-    ClearSwCallbacks(ptn->psw, 2, (PFNMQ)nullptr, ptn, MSGID_Nil, nullptr);
+    ClearSwCallbacks(ptn->psw, 2, NULL, ptn, MSGID_Nil, NULL);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/tn", LoadTnFromBrx__FP2TNP18CBinaryInputStream);
@@ -36,7 +36,7 @@ void FUN_001e2840(TN *ptn, TNS tns)
     }
 
     STRUCT_OFFSET(ptn, 0x398, TNS) = tns;
-    UpdateTnCallback(ptn, MSGID_callback, nullptr);
+    UpdateTnCallback(ptn, MSGID_callback, NULL);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/tn", UpdateTnCallback__FP2TN5MSGIDPv);
@@ -46,7 +46,7 @@ void UpdateTn(TN *ptn, float dt)
     UpdateAlo(ptn, dt);
     if (STRUCT_OFFSET(ptn, 0x398, TNS) != TNS_Out) // ptn->tns
     {
-        PostSwCallback(ptn->psw, UpdateTnCallback, ptn, MSGID_callback, nullptr);
+        PostSwCallback(ptn->psw, UpdateTnCallback, ptn, MSGID_callback, NULL);
     }
 }
 

--- a/src/P2/transition.c
+++ b/src/P2/transition.c
@@ -9,7 +9,7 @@
 
 CTransition::CTransition()
 {
-    m_pchzWorld = (char*)nullptr;
+    m_pchzWorld = NULL;
     grftrans = FTRANS_None;
     m_oidWarp = OID_Nil;
     m_oidWarpContext = OID_Nil;

--- a/src/P2/ub.c
+++ b/src/P2/ub.c
@@ -76,7 +76,7 @@ void DoUbgFreefallLanding(UBG *pubg)
     // pubg->oidPatrolGoal & pubg->sgs
     if (STRUCT_OFFSET(pubg, 0xc58, OID) == OID_state_ubb_round_2 &&
         STRUCT_OFFSET(pubg, 0x724, SGS) == SGS_Pursue &&
-        PxpFindSoGround(pubg, (SO *)nullptr, (int *)nullptr))
+        PxpFindSoGround(pubg, NULL, NULL))
     {
         SO *pso = PsoPadUbgClosest(pubg, &STRUCT_OFFSET(pubg, 0x140, VECTOR));
 

--- a/src/P2/waypoint.c
+++ b/src/P2/waypoint.c
@@ -69,7 +69,7 @@ void EnsureWpsgCallback(WPSG *pwpsg)
     if (!pwpsg->fCallback)
     {
         pwpsg->fCallback = 1;
-        PostSwCallback(g_psw, UpdateWpsgCallback, pwpsg, MSGID_Nil, nullptr);
+        PostSwCallback(g_psw, UpdateWpsgCallback, pwpsg, MSGID_Nil, NULL);
     }
 }
 

--- a/src/P2/wr.c
+++ b/src/P2/wr.c
@@ -44,7 +44,7 @@ WRE *PwreGetWrCur(WR *pwr, ENSK ensk, WREK wrek)
 {
     if (pwr->cwre == 0)
     {
-        return (WRE *)nullptr;
+        return NULL;
     }
     if (ensk == ENSK_Set)
     {

--- a/src/P2/xform.c
+++ b/src/P2/xform.c
@@ -22,20 +22,20 @@ void SetXfmParent(XFM *pxfm, ALO *paloParent)
 
 void ApplyXfmProxy(XFM *pxfm, PROXY *pproxyApply)
 {
-    ConvertAloPos(pproxyApply, (ALO *)nullptr, &pxfm->posLocal, &pxfm->posLocal);
-    ConvertAloMat(pproxyApply, (ALO *)nullptr, &pxfm->matLocal, &pxfm->matLocal);
+    ConvertAloPos(pproxyApply, NULL, &pxfm->posLocal, &pxfm->posLocal);
+    ConvertAloMat(pproxyApply, NULL, &pxfm->matLocal, &pxfm->matLocal);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/xform", ConvertXfmLocalToWorld__FP3XFMP6VECTORT1);
 
 void GetXfmPos(XFM *pxfm, VECTOR *ppos)
 {
-    ConvertAloPos(pxfm->paloParent, (ALO *)nullptr, &pxfm->posLocal, ppos);
+    ConvertAloPos(pxfm->paloParent, NULL, &pxfm->posLocal, ppos);
 }
 
 void GetXfmMat(XFM *pxfm, MATRIX3 *pmat)
 {
-    ConvertAloMat(pxfm->paloParent, (ALO *)nullptr, &pxfm->matLocal, pmat);
+    ConvertAloMat(pxfm->paloParent, NULL, &pxfm->matLocal, pmat);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/xform", PwarpFromOid__F3OIDT0);
@@ -114,7 +114,7 @@ void EnableCamera(CAMERA *pcamera)
     if (STRUCT_OFFSET(pcamera, 0x310, int) == 0) // pcamera->fSetCplcy
     {
         // g_pcm->cpaseg
-        SetCmPolicy(g_pcm, CPP_Animated, &STRUCT_OFFSET(g_pcm, 0x510, CPLCY), (SO *)nullptr, pcamera);
+        SetCmPolicy(g_pcm, CPP_Animated, &STRUCT_OFFSET(g_pcm, 0x510, CPLCY), NULL, pcamera);
         STRUCT_OFFSET(pcamera, 0x310, int) = 1; // pcamera->fSetCplcy
     }
 }
@@ -124,7 +124,7 @@ void DisableCamera(CAMERA *pcamera)
     if (STRUCT_OFFSET(pcamera, 0x310, int) != 0) // pcamera->fSetCplcy
     {
         // g_pcm->cpaseg
-        RevokeCmPolicy(g_pcm, 0x0b, CPP_Animated, &STRUCT_OFFSET(g_pcm, 0x510, CPLCY), (SO *)nullptr, pcamera);
+        RevokeCmPolicy(g_pcm, 0x0b, CPP_Animated, &STRUCT_OFFSET(g_pcm, 0x510, CPLCY), NULL, pcamera);
         STRUCT_OFFSET(pcamera, 0x310, int) = 0; // pcamera->fSetCplcy
     }
 }

--- a/src/P2/zap.c
+++ b/src/P2/zap.c
@@ -53,7 +53,7 @@ void InitVolzp(VOLZP *pvolzp)
 {
     InitTzp(pvolzp);
     STRUCT_OFFSET(pvolzp, 0x538, ulong) |= 0x80000000000; // ptzp->bspcCamera.absp
-    SetSoConstraints(pvolzp, CT_Locked, (VECTOR *)nullptr, CT_Locked, (VECTOR *)nullptr);
+    SetSoConstraints(pvolzp, CT_Locked, NULL, CT_Locked, NULL);
 }
 
 INCLUDE_ASM("asm/nonmatchings/P2/zap", UpdateVolzp__FP5VOLZPf);
@@ -75,7 +75,7 @@ void InflictZpdZap(ZPD *pzpd, XP *pxp, ZPR *pzpr)
     pzpr->zpk = pzpd->zpk;
     pzpr->pv = pzpd;
     pzpr->pfnzap = ApplyZpdThrow;
-    HandleLoSpliceEvent(pzpd->pso, 2, 0, (void **)nullptr);
+    HandleLoSpliceEvent(pzpd->pso, 2, 0, NULL);
 }
 
 void AddZpdZapObject(ZPD *pzpd, OID oid)


### PR DESCRIPTION
`nullptr` was not introduced until C++11 so we should be using the period accurate `NULL`.