### PR TITLE
Update workflows to use new build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "*"
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -12,30 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U -r requirements.txt
-
-      - name: Setup wine
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install wine32
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup build environment
         run: |
-          sudo apt-get install binutils-mips-linux-gnu
-          scripts/setup_prodg_linux.sh
+          scripts/quickstart.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
       - name: Run build script
-        run: |
-          python configure.py
-          ninja
+        run: scripts/build.sh

--- a/.github/workflows/frogress.yml
+++ b/.github/workflows/frogress.yml
@@ -13,32 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U -r requirements.txt
-
-      - name: Setup wine
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install wine32
-
       - name: Setup build environment
         run: |
-          sudo apt-get install binutils-mips-linux-gnu
-          scripts/setup_prodg_linux.sh
+          scripts/quickstart.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
       - name: Run build script
-        run: |
-          python configure.py
-          ninja
+        run: scripts/build.sh
 
       - name: Post to frogress endpoint
         run: |

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -14,26 +14,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9.x"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -U -r requirements.txt
-
-      - name: Setup wine
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install wine32
-
       - name: Setup build environment
         run: |
-          sudo apt-get install binutils-mips-linux-gnu
-          scripts/setup_prodg_linux.sh
+          scripts/quickstart.sh
           curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
 
       - name: Configure and generate report


### PR DESCRIPTION
This updates the GitHub Actions workflows to use the overhauled build scripts introduced in #244. This should include using Wibo instead of Wine when possible. It also should make the build workflow run on PRs targeting this repo for automated build status checking.