### PR TITLE
Add build-objects workflow

### DIFF
--- a/.github/workflows/build-objects.yml
+++ b/.github/workflows/build-objects.yml
@@ -1,0 +1,30 @@
+name: Build with objdiff objects for pull requests
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-objects:
+    if: github.repository_owner == 'theonlyzac'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup build environment
+        run: scripts/quickstart.sh
+
+      - name: Activate virtualenv
+        run: echo "${{ github.workspace }}/env/bin" >> $GITHUB_PATH
+
+      - name: Fetch game executable
+        run: curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
+
+      - name: Configure and build
+        run: |
+          python configure.py --objects
+          ninja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build project and validate checksum
 on:
   push:
     branches:
-      - "*"
+      - main
   pull_request_target:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Added workflow for building objdiff objects which runs only on PRs to validate that fuzzy matches build successfully,and the objdiff report will generate when merged to main. Also updated regular build workflow to run on only on push to main branch and PRs.