### PR TITLE
Add CI workflow to auto-update Doxygen docs on gh-pages branch

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Generate docs
         run: |
+          rm -rf html
           cp Doxyfile sly1/
+          cp sly1/docs/logo.png sly1/
           cd sly1
           doxygen Doxyfile
           cp -r docs html

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -9,6 +9,9 @@ jobs:
   docs:
     if: github.repository_owner == 'theonlyzac'
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-doxygen
+      cancel-in-progress: true
     permissions:
       contents: write
 
@@ -26,7 +29,9 @@ jobs:
           path: sly1
 
       - name: Install Doxygen and Graphviz
-        run: sudo apt-get install -y doxygen graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
 
       - name: Preprocess headers
         run: |

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,52 @@
+name: Update Doxygen docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    if: github.repository_owner == 'theonlyzac'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          submodules: recursive
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: sly1
+
+      - name: Install Doxygen and Graphviz
+        run: sudo apt-get install -y doxygen graphviz
+
+      - name: Preprocess headers
+        run: |
+          for file in $(find sly1/include/ -name "*.h"); do
+            sed -i '/#include "common.h"/d' "$file"
+          done
+
+      - name: Generate docs
+        run: |
+          cp Doxyfile sly1/
+          cd sly1
+          doxygen Doxyfile
+          cp -r docs html
+          mv html/ ..
+
+      - name: Commit and push to gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add html/
+          git diff --cached --quiet && echo "No changes to commit" || \
+            git commit -m "docs: update doxygen docs from main @ ${{ github.sha }}"
+          git push origin gh-pages


### PR DESCRIPTION
Triggers on every push to main. Checks out `gh-pages` and `main` into ./sly1/, then replicates the manual steps
in generate.sh: strips `#include "common.h"` from headers, runs doxygen, and force-commits the updated html/ directory back to gh-pages.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011NDfvdWjURZNnXERVyz8o7