### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-objects.yml
+++ b/.github/workflows/build-objects.yml
@@ -4,16 +4,32 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Only what actions/checkout needs. On a public repo this grants nothing an
+# anonymous clone doesn't already have, and it stops a job that executes
+# contributor-authored build scripts from being able to write to the repo.
+permissions:
+  contents: read
+
 jobs:
+  # Untrusted: pull_request_target runs with the base repo's secrets, and the
+  # build executes scripts from the PR branch. The pr-build environment holds
+  # this until a maintainer approves the run, which is tied to the head SHA, so
+  # every push to the PR is re-approved.
   build-objects:
     if: github.repository_owner == 'theonlyzac'
     runs-on: ubuntu-latest
+    environment: pr-build
+    concurrency:
+      group: build-objects-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup build environment
         run: scripts/quickstart.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,49 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Only what actions/checkout needs. On a public repo this grants nothing an
+# anonymous clone doesn't already have, and it stops a job that executes
+# contributor-authored build scripts from being able to write to the repo.
+permissions:
+  contents: read
+
 jobs:
-  build:
-    if: github.repository_owner == 'theonlyzac'
+  # Trusted: the code being built is already on main.
+  build-main:
+    if: github.event_name == 'push' && github.repository_owner == 'theonlyzac'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup build environment
+        run: |
+          scripts/quickstart.sh
+          curl -o disc/SCUS_971.98 "${{ secrets.FILE_URL }}"
+
+      - name: Run build script
+        run: scripts/build.sh
+
+  # Untrusted: pull_request_target runs with the base repo's secrets, and the
+  # build executes scripts from the PR branch. The pr-build environment holds
+  # this until a maintainer approves the run, which is tied to the head SHA, so
+  # every push to the PR is re-approved.
+  build-pr:
+    if: github.event_name == 'pull_request_target' && github.repository_owner == 'theonlyzac'
+    runs-on: ubuntu-latest
+    environment: pr-build
+    concurrency:
+      group: build-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Setup build environment
         run: |


### PR DESCRIPTION
**Both workflows**
- Add a top-level `permissions: contents: read`. On a public repo this grants nothing an anonymous clone doesn't already have, and it removes the default write-scoped token from a job that runs contributor-authored scripts.
- `persist-credentials: false` on checkout, so no token is left behind in `.git/config` for build scripts to pick up.
- Gate the PR job behind an `environment: pr-build`, so a maintainer has to approve each run. Approval is tied to the head SHA, so every push to a PR is re-approved rather than approved once.
- Add a per-PR `concurrency` group with `cancel-in-progress: true`, so pushing repeatedly to a PR queues one pending approval instead of a stack of them.
- Pass `allow-unsafe-pr-checkout: true` — an explicit acknowledgement that this checkout is untrusted PR code under `pull_request_target`, rather than relying on the action's default.

**`build.yml` specifically**
- Split the single `build` job into `build-main` (push, trusted — the code is already on `main`) and `build-pr` (`pull_request_target`, untrusted). Only `build-pr` carries the environment gate and concurrency group; pushes to `main` still build without waiting on approval.
- Bump `actions/checkout@v2` → `@v4`.
- The `ref: ${{ github.event.pull_request.head.sha || github.sha }}` fallback goes away — each job now has one event and one unambiguous ref.

**Inline comments** explaining the trusted/untrusted split are in both files, so the reasoning survives the next edit to these workflows.

## Required repo setup before merging

The environment gate is inert without configuration. In **Settings → Environments**, create an environment named `pr-build` and add **Required reviewers**. Without a protection rule, `environment: pr-build` resolves and the job runs immediately, so the workflows would be no worse than today but the approval step would do nothing.

## Notes

- This does not switch the workflows away from `pull_request_target`. Moving to `pull_request` would drop the need for the approval gate, but PR builds would lose `secrets.FILE_URL` and couldn't fetch the game executable. Keeping `pull_request_target` + manual approval preserves the current developer experience.
- `doxygen.yml`, `frogress.yml`, and `progress.yml` are untouched — none of them use `pull_request_target`.