### PR TITLE
matched InitCplcy

### DIFF
--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -1531,7 +1531,7 @@ s_asnipDprize = 0x2619A0; // size:0x3c
 ////////////////////////////////////////////////////////////////
 // P2/cplcy.c
 ////////////////////////////////////////////////////////////////
-InitCplcy = 0x149398; // type:func
+InitCplcy__FP5CPLCYP2CM = 0x149398; // type:func
 FActiveCplcy = 0x1493A0; // type:func
 SetCpmanCpmt = 0x1493B8; // type:func
 FUN_001493c0__Fv = 0x1493C0; // type:func

--- a/include/cplcy.h
+++ b/include/cplcy.h
@@ -11,6 +11,8 @@
 #include "common.h"
 #include <cm.h>
 
+extern "C" void InitCplcy(CPLCY *pcplcy, CM *pcm);
+
 void PushCplookLookk(CPLOOK *pcplook, LOOKK lookk);
 
 LOOKK LookkPopCplook(CPLOOK *pcplook);

--- a/include/cplcy.h
+++ b/include/cplcy.h
@@ -11,7 +11,7 @@
 #include "common.h"
 #include <cm.h>
 
-extern "C" void InitCplcy(CPLCY *pcplcy, CM *pcm);
+void InitCplcy(CPLCY *pcplcy, CM *pcm);
 
 void PushCplookLookk(CPLOOK *pcplook, LOOKK lookk);
 

--- a/src/P2/cplcy.c
+++ b/src/P2/cplcy.c
@@ -3,7 +3,10 @@
  */
 #include <cplcy.h>
 
-INCLUDE_ASM("asm/nonmatchings/P2/cplcy", InitCplcy);
+void InitCplcy(CPLCY *pcplcy, CM *pcm)
+{
+    pcplcy->pcm = pcm;
+}
 
 INCLUDE_ASM("asm/nonmatchings/P2/cplcy", FActiveCplcy);
 


### PR DESCRIPTION
Matches InitCplcy, the shared base-struct initializer for camera objects.

https://decomp.me/scratch/Oxox4

[288/288] sha1sum config/checksum.sha1
out/SCUS_971.98: OK

Added a prototype for InitCplcy in include/cplcy.h
- ~~Declared extern "C" because the original binary's symbol is unmangled~~
Added the mangled name for InitCplcy to symbol_addrs.txt
