### PR TITLE
cplcy matching

### DIFF
--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -1532,7 +1532,7 @@ s_asnipDprize = 0x2619A0; // size:0x3c
 // P2/cplcy.c
 ////////////////////////////////////////////////////////////////
 InitCplcy__FP5CPLCYP2CM = 0x149398; // type:func
-FActiveCplcy = 0x1493A0; // type:func
+FActiveCplcy__FP5CPLCY = 0x1493A0; // type:func
 SetCpmanCpmt__FP5CPMAN4CPMT = 0x1493B8; // type:func
 FUN_001493c0__Fv = 0x1493C0; // type:func
 PosCplookAnchor = 0x1493C8; // type:func

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -1533,7 +1533,7 @@ s_asnipDprize = 0x2619A0; // size:0x3c
 ////////////////////////////////////////////////////////////////
 InitCplcy__FP5CPLCYP2CM = 0x149398; // type:func
 FActiveCplcy = 0x1493A0; // type:func
-SetCpmanCpmt = 0x1493B8; // type:func
+SetCpmanCpmt__FP5CPMAN4CPMT = 0x1493B8; // type:func
 FUN_001493c0__Fv = 0x1493C0; // type:func
 PosCplookAnchor = 0x1493C8; // type:func
 FUN_00149458 = 0x149458; // type:func

--- a/include/cplcy.h
+++ b/include/cplcy.h
@@ -13,6 +13,8 @@
 
 void InitCplcy(CPLCY *pcplcy, CM *pcm);
 
+void SetCpmanCpmt(CPMAN *pcpman, CPMT cpmt);
+
 void PushCplookLookk(CPLOOK *pcplook, LOOKK lookk);
 
 LOOKK LookkPopCplook(CPLOOK *pcplook);

--- a/include/cplcy.h
+++ b/include/cplcy.h
@@ -13,6 +13,8 @@
 
 void InitCplcy(CPLCY *pcplcy, CM *pcm);
 
+int FActiveCplcy(CPLCY *pcplcy);
+
 void SetCpmanCpmt(CPMAN *pcpman, CPMT cpmt);
 
 void PushCplookLookk(CPLOOK *pcplook, LOOKK lookk);

--- a/src/P2/cplcy.c
+++ b/src/P2/cplcy.c
@@ -8,7 +8,10 @@ void InitCplcy(CPLCY *pcplcy, CM *pcm)
     pcplcy->pcm = pcm;
 }
 
-INCLUDE_ASM("asm/nonmatchings/P2/cplcy", FActiveCplcy);
+int FActiveCplcy(CPLCY *pcplcy)
+{
+    return STRUCT_OFFSET(pcplcy->pcm, 0x3D8, CPLCY *) == pcplcy;
+}
 
 void SetCpmanCpmt(CPMAN *pcpman, CPMT cpmt)
 {

--- a/src/P2/cplcy.c
+++ b/src/P2/cplcy.c
@@ -10,7 +10,10 @@ void InitCplcy(CPLCY *pcplcy, CM *pcm)
 
 INCLUDE_ASM("asm/nonmatchings/P2/cplcy", FActiveCplcy);
 
-INCLUDE_ASM("asm/nonmatchings/P2/cplcy", SetCpmanCpmt);
+void SetCpmanCpmt(CPMAN *pcpman, CPMT cpmt)
+{
+    pcpman->cpmt = cpmt;
+}
 
 void FUN_001493c0(void)
 {


### PR DESCRIPTION
Continuing cplcy work:

Matched 
`SetCpmanCpmt`
`FActiveCplcy` - Note: set return type to int to match other `f*` prefix functions.

Both symbols were unmangled, found mangled symbols in the 2002 build.

[288/288] sha1sum config/checksum.sha1
out/SCUS_971.98: OK